### PR TITLE
feat: implement header escaping per STOMP 1.2 spec

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -50,6 +50,17 @@ impl Frame {
         self.body = body.into();
         self
     }
+
+    /// Get the value of a header by name.
+    ///
+    /// Returns the first header value matching the given key (case-sensitive),
+    /// or `None` if no such header exists.
+    pub fn get_header(&self, key: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
 }
 
 impl fmt::Display for Frame {

--- a/tests/header_escaping.rs
+++ b/tests/header_escaping.rs
@@ -1,0 +1,449 @@
+//! Tests for STOMP 1.2 header escaping/unescaping per spec.
+//!
+//! STOMP 1.2 requires these escape sequences in header names and values:
+//! - `\r` → carriage return (0x0d)
+//! - `\n` → line feed (0x0a)
+//! - `\c` → colon (0x3a)
+//! - `\\` → backslash (0x5c)
+
+use bytes::BytesMut;
+use iridium_stomp::Frame;
+use iridium_stomp::codec::{StompCodec, StompItem};
+use tokio_util::codec::{Decoder, Encoder};
+
+// ============================================================================
+// Unescape tests (parsing incoming frames)
+// ============================================================================
+
+#[test]
+fn unescape_backslash() {
+    // Frame with escaped backslash in header value
+    let raw = b"MESSAGE\nheader:value\\\\with\\\\backslashes\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let item = codec.decode(&mut buf).unwrap().unwrap();
+    match item {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("header"), Some("value\\with\\backslashes"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn unescape_newline() {
+    // Frame with escaped newline in header value
+    let raw = b"MESSAGE\nheader:line1\\nline2\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let item = codec.decode(&mut buf).unwrap().unwrap();
+    match item {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("header"), Some("line1\nline2"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn unescape_carriage_return() {
+    // Frame with escaped carriage return in header value
+    let raw = b"MESSAGE\nheader:before\\rafter\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let item = codec.decode(&mut buf).unwrap().unwrap();
+    match item {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("header"), Some("before\rafter"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn unescape_colon() {
+    // Frame with escaped colon in header value
+    let raw = b"MESSAGE\nheader:key\\cvalue\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let item = codec.decode(&mut buf).unwrap().unwrap();
+    match item {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("header"), Some("key:value"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn unescape_multiple_sequences() {
+    // Frame with multiple escape sequences
+    let raw = b"MESSAGE\nheader:a\\nb\\rc\\\\d\\ce\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let item = codec.decode(&mut buf).unwrap().unwrap();
+    match item {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("header"), Some("a\nb\rc\\d:e"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn unescape_header_name() {
+    // Escaped characters in header name (unusual but spec allows)
+    let raw = b"MESSAGE\nkey\\nname:value\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let item = codec.decode(&mut buf).unwrap().unwrap();
+    match item {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("key\nname"), Some("value"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn unescape_invalid_sequence() {
+    // Invalid escape sequence should produce error
+    let raw = b"MESSAGE\nheader:bad\\xescape\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let result = codec.decode(&mut buf);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("invalid escape"));
+}
+
+#[test]
+fn unescape_incomplete_sequence() {
+    // Incomplete escape at end of header value
+    let raw = b"MESSAGE\nheader:trailing\\\n\n\0";
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&raw[..]);
+
+    let result = codec.decode(&mut buf);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("incomplete escape"));
+}
+
+// ============================================================================
+// Escape tests (encoding outgoing frames)
+// ============================================================================
+
+#[test]
+fn escape_backslash() {
+    let frame = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("custom", "path\\to\\file");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec.encode(StompItem::Frame(frame), &mut buf).unwrap();
+
+    let encoded = String::from_utf8_lossy(&buf);
+    assert!(encoded.contains("custom:path\\\\to\\\\file"));
+}
+
+#[test]
+fn escape_newline() {
+    let frame = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("custom", "line1\nline2");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec.encode(StompItem::Frame(frame), &mut buf).unwrap();
+
+    let encoded = String::from_utf8_lossy(&buf);
+    assert!(encoded.contains("custom:line1\\nline2"));
+}
+
+#[test]
+fn escape_carriage_return() {
+    let frame = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("custom", "before\rafter");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec.encode(StompItem::Frame(frame), &mut buf).unwrap();
+
+    let encoded = String::from_utf8_lossy(&buf);
+    assert!(encoded.contains("custom:before\\rafter"));
+}
+
+#[test]
+fn escape_colon() {
+    let frame = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("custom", "key:value");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec.encode(StompItem::Frame(frame), &mut buf).unwrap();
+
+    let encoded = String::from_utf8_lossy(&buf);
+    assert!(encoded.contains("custom:key\\cvalue"));
+}
+
+#[test]
+fn escape_multiple_characters() {
+    let frame = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("custom", "a\nb\rc\\d:e");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec.encode(StompItem::Frame(frame), &mut buf).unwrap();
+
+    let encoded = String::from_utf8_lossy(&buf);
+    assert!(encoded.contains("custom:a\\nb\\rc\\\\d\\ce"));
+}
+
+// ============================================================================
+// Round-trip tests (encode then decode)
+// ============================================================================
+
+#[test]
+fn roundtrip_backslash() {
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("path", "C:\\Users\\test\\file.txt");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("path"), Some("C:\\Users\\test\\file.txt"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn roundtrip_newline() {
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("multiline", "first\nsecond\nthird");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("multiline"), Some("first\nsecond\nthird"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn roundtrip_carriage_return() {
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("windows", "line1\r\nline2");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("windows"), Some("line1\r\nline2"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn roundtrip_colon() {
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("url", "http://example.com:8080/path");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(
+                frame.get_header("url"),
+                Some("http://example.com:8080/path")
+            );
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn roundtrip_all_special_chars() {
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("complex", "path\\to\\file\nkey:value\r\nend");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(
+                frame.get_header("complex"),
+                Some("path\\to\\file\nkey:value\r\nend")
+            );
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn roundtrip_empty_value() {
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("empty", "");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("empty"), Some(""));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn roundtrip_only_special_chars() {
+    // Header value that is ONLY special characters
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("special", "\\\n\r:");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("special"), Some("\\\n\r:"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+#[test]
+fn no_escaping_needed() {
+    // Normal header value with no special characters should pass through unchanged
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("normal", "just-a-normal-value");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    // Verify no escape sequences in the encoded output
+    let encoded = String::from_utf8_lossy(&buf);
+    assert!(encoded.contains("normal:just-a-normal-value"));
+    assert!(!encoded.contains("\\\\"));
+    assert!(!encoded.contains("\\n"));
+    assert!(!encoded.contains("\\r"));
+    assert!(!encoded.contains("\\c"));
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("normal"), Some("just-a-normal-value"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn consecutive_escapes() {
+    // Multiple consecutive escape sequences
+    let original = Frame::new("SEND")
+        .header("destination", "/queue/test")
+        .header("consecutive", "\n\n\n\\\\\\");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(frame.get_header("consecutive"), Some("\n\n\n\\\\\\"));
+        }
+        _ => panic!("expected frame"),
+    }
+}
+
+#[test]
+fn destination_with_colon() {
+    // Destination header containing colon (common in URLs)
+    let original = Frame::new("SEND").header("destination", "/queue/http://example.com:8080");
+
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::new();
+    codec
+        .encode(StompItem::Frame(original.clone()), &mut buf)
+        .unwrap();
+
+    let decoded = codec.decode(&mut buf).unwrap().unwrap();
+    match decoded {
+        StompItem::Frame(frame) => {
+            assert_eq!(
+                frame.get_header("destination"),
+                Some("/queue/http://example.com:8080")
+            );
+        }
+        _ => panic!("expected frame"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements STOMP 1.2 header escaping/unescaping per specification §2.3.2.

**Escape sequences implemented:**
| Wire Format | Decoded Value |
|-------------|---------------|
| `\\` | `\` (backslash) |
| `\n` | LF (0x0a) |
| `\r` | CR (0x0d) |
| `\c` | `:` (colon) |

**Changes:**
- Add `unescape_header_value()` in `parser.rs`
- Add `escape_header_value()` in `codec.rs`  
- Integrate escaping into encode/decode paths
- Add `Frame::get_header()` helper method
- Add 23 comprehensive tests in `tests/header_escaping.rs`

## Test plan

- [x] All 198 existing tests pass (no regressions)
- [x] 23 new header escaping tests cover:
  - Unescape: backslash, newline, CR, colon, multiple sequences
  - Escape: same characters
  - Round-trip: encode then decode preserves values
  - Error cases: invalid/incomplete escape sequences
- [ ] CI passes

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)