### PR TITLE
feat: surface ERROR frames as first-class type (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configurable `host` header for virtual hosts
   - Configurable `accept-version` for STOMP version negotiation
   - Custom headers support for broker-specific requirements
+- ERROR frames surfaced as first-class type ([#35])
+  - `ReceivedFrame` enum distinguishes normal frames from errors
+  - `ServerError` struct with `message`, `body`, `receipt_id`, and original frame
+  - `Connection::next_frame()` now returns `Option<ReceivedFrame>` (**breaking change**)
+  - Pattern matching enables type-safe error handling
 - `Frame::get_header()` helper method for retrieving header values
 
 ## [0.1.0] - 2025-01-14
@@ -50,4 +55,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#32]: https://github.com/bsiegfreid/iridium-stomp/issues/32
 [#33]: https://github.com/bsiegfreid/iridium-stomp/issues/33
 [#34]: https://github.com/bsiegfreid/iridium-stomp/issues/34
+[#35]: https://github.com/bsiegfreid/iridium-stomp/issues/35
 [#37]: https://github.com/bsiegfreid/iridium-stomp/pull/37

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ iridium-stomp = { git = "https://github.com/bsiegfreid/iridium-stomp", branch = 
 
 ## Quick Start
 
-```rust
+```rust,no_run
 use iridium_stomp::{Connection, Frame};
 
 #[tokio::main]
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Heartbeats are negotiated automatically during connection. Pass your desired
 intervals in the `heart-beat` format (`send,receive` in milliseconds):
 
-```rust
+```rust,ignore
 // Client wants to send heartbeats every 10 seconds
 // and receive them every 10 seconds
 let conn = Connection::connect(addr, login, pass, "10000,10000").await?;
@@ -124,7 +124,7 @@ connection if the server stops responding.
 
 Subscribe to destinations with automatic resubscription on reconnect:
 
-```rust
+```rust,ignore
 use iridium_stomp::connection::AckMode;
 
 // Auto-acknowledge (server considers delivered immediately)
@@ -139,8 +139,9 @@ let sub = conn.subscribe("/queue/tasks", AckMode::ClientIndividual).await?;
 
 For broker-specific headers (durable subscriptions, selectors, etc.):
 
-```rust
+```rust,ignore
 use iridium_stomp::SubscriptionOptions;
+use iridium_stomp::connection::AckMode;
 
 let options = SubscriptionOptions {
     headers: vec![
@@ -158,7 +159,7 @@ let sub = conn.subscribe_with_options("/topic/events", AckMode::Client, options)
 The `Connection` is cloneable and thread-safe. Multiple tasks can share the
 same connection:
 
-```rust
+```rust,ignore
 let conn = Connection::connect(...).await?;
 let conn2 = conn.clone();
 
@@ -197,7 +198,7 @@ stomp -s /queue/orders -s /queue/notifications
 
 Interactive commands:
 
-```
+```text
 > send /queue/test Hello, World!
 Sent to /queue/test
 

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -1,4 +1,4 @@
-use iridium_stomp::{Connection, Frame};
+use iridium_stomp::{Connection, Frame, ReceivedFrame};
 use std::time::Duration;
 
 #[tokio::main]
@@ -16,7 +16,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Try to read one incoming frame (if any), but don't block forever — time out after 5s.
     match tokio::time::timeout(Duration::from_secs(5), conn.next_frame()).await {
-        Ok(Some(frame)) => println!("received frame:\n{}", frame),
+        Ok(Some(ReceivedFrame::Frame(frame))) => println!("received frame:\n{}", frame),
+        Ok(Some(ReceivedFrame::Error(err))) => println!("server error: {}", err),
         Ok(None) => println!("connection closed, no frames received"),
         Err(_) => println!("timed out waiting for a frame"),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@ pub mod subscription;
 /// `tokio_util::codec::Framed` and tests.
 pub use codec::{StompCodec, StompItem};
 
-/// Re-export the high-level `Connection`, `AckMode`, `ConnectOptions`, `ConnError`, and the heartbeat helper functions.
+/// Re-export the high-level `Connection`, `AckMode`, `ConnectOptions`, `ConnError`,
+/// `ReceivedFrame`, `ServerError`, and the heartbeat helper functions.
 pub use connection::{
-    AckMode, ConnError, ConnectOptions, Connection, negotiate_heartbeats, parse_heartbeat_header,
+    AckMode, ConnError, ConnectOptions, Connection, ReceivedFrame, ServerError,
+    negotiate_heartbeats, parse_heartbeat_header,
 };
 
 /// Re-export the `Frame` type used to construct/send and receive frames.

--- a/tests/error_frame_tests.rs
+++ b/tests/error_frame_tests.rs
@@ -1,0 +1,313 @@
+//! Tests for ERROR frame handling (Issue #35)
+//!
+//! These tests verify:
+//! - ServerError struct creation and fields
+//! - ReceivedFrame enum variants and methods
+//! - Display and Error trait implementations
+
+use iridium_stomp::{Frame, ReceivedFrame, ServerError};
+
+// ============================================================================
+// ServerError tests
+// ============================================================================
+
+#[test]
+fn server_error_from_frame_basic() {
+    let frame = Frame::new("ERROR")
+        .header("message", "malformed frame received")
+        .header("content-type", "text/plain");
+
+    let err = ServerError::from_frame(frame);
+
+    assert_eq!(err.message, "malformed frame received");
+    assert!(err.body.is_none());
+    assert!(err.receipt_id.is_none());
+}
+
+#[test]
+fn server_error_from_frame_with_body() {
+    let frame = Frame::new("ERROR")
+        .header("message", "authentication failed")
+        .set_body(b"Invalid credentials provided".to_vec());
+
+    let err = ServerError::from_frame(frame);
+
+    assert_eq!(err.message, "authentication failed");
+    assert_eq!(err.body, Some("Invalid credentials provided".to_string()));
+}
+
+#[test]
+fn server_error_from_frame_with_receipt_id() {
+    let frame = Frame::new("ERROR")
+        .header("message", "invalid destination")
+        .header("receipt-id", "msg-12345");
+
+    let err = ServerError::from_frame(frame);
+
+    assert_eq!(err.message, "invalid destination");
+    assert_eq!(err.receipt_id, Some("msg-12345".to_string()));
+}
+
+#[test]
+fn server_error_from_frame_no_message_header() {
+    let frame = Frame::new("ERROR");
+
+    let err = ServerError::from_frame(frame);
+
+    assert_eq!(err.message, "unknown error");
+}
+
+#[test]
+fn server_error_from_frame_preserves_original() {
+    let frame = Frame::new("ERROR")
+        .header("message", "test error")
+        .header("custom-header", "custom-value")
+        .set_body(b"body content".to_vec());
+
+    let err = ServerError::from_frame(frame);
+
+    // Original frame should be accessible
+    assert_eq!(err.frame.command, "ERROR");
+    assert_eq!(err.frame.get_header("custom-header"), Some("custom-value"));
+}
+
+#[test]
+fn server_error_display_basic() {
+    let frame = Frame::new("ERROR").header("message", "connection refused");
+
+    let err = ServerError::from_frame(frame);
+    let display = format!("{}", err);
+
+    assert!(display.contains("STOMP server error"));
+    assert!(display.contains("connection refused"));
+}
+
+#[test]
+fn server_error_display_with_body() {
+    let frame = Frame::new("ERROR")
+        .header("message", "protocol error")
+        .set_body(b"details here".to_vec());
+
+    let err = ServerError::from_frame(frame);
+    let display = format!("{}", err);
+
+    assert!(display.contains("protocol error"));
+    assert!(display.contains("details here"));
+}
+
+#[test]
+fn server_error_debug() {
+    let frame = Frame::new("ERROR").header("message", "test");
+
+    let err = ServerError::from_frame(frame);
+    let debug = format!("{:?}", err);
+
+    assert!(debug.contains("ServerError"));
+    assert!(debug.contains("test"));
+}
+
+#[test]
+fn server_error_is_error_trait() {
+    let frame = Frame::new("ERROR").header("message", "test");
+    let err = ServerError::from_frame(frame);
+
+    // Verify it implements std::error::Error
+    let _: &dyn std::error::Error = &err;
+}
+
+#[test]
+fn server_error_clone() {
+    let frame = Frame::new("ERROR")
+        .header("message", "test")
+        .set_body(b"body".to_vec());
+
+    let err1 = ServerError::from_frame(frame);
+    let err2 = err1.clone();
+
+    assert_eq!(err1.message, err2.message);
+    assert_eq!(err1.body, err2.body);
+}
+
+#[test]
+fn server_error_eq() {
+    let frame1 = Frame::new("ERROR").header("message", "test");
+    let frame2 = Frame::new("ERROR").header("message", "test");
+
+    let err1 = ServerError::from_frame(frame1);
+    let err2 = ServerError::from_frame(frame2);
+
+    assert_eq!(err1, err2);
+}
+
+// ============================================================================
+// ReceivedFrame tests
+// ============================================================================
+
+#[test]
+fn received_frame_is_error() {
+    let frame = Frame::new("ERROR").header("message", "test");
+    let err = ServerError::from_frame(frame);
+    let received = ReceivedFrame::Error(err);
+
+    assert!(received.is_error());
+    assert!(!received.is_frame());
+}
+
+#[test]
+fn received_frame_is_frame() {
+    let frame = Frame::new("MESSAGE")
+        .header("destination", "/queue/test")
+        .set_body(b"hello".to_vec());
+    let received = ReceivedFrame::Frame(frame);
+
+    assert!(received.is_frame());
+    assert!(!received.is_error());
+}
+
+#[test]
+fn received_frame_into_frame_success() {
+    let frame = Frame::new("MESSAGE").header("destination", "/queue/test");
+    let received = ReceivedFrame::Frame(frame);
+
+    let result = received.into_frame();
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().command, "MESSAGE");
+}
+
+#[test]
+fn received_frame_into_frame_from_error() {
+    let frame = Frame::new("ERROR").header("message", "test");
+    let err = ServerError::from_frame(frame);
+    let received = ReceivedFrame::Error(err);
+
+    let result = received.into_frame();
+    assert!(result.is_none());
+}
+
+#[test]
+fn received_frame_into_error_success() {
+    let frame = Frame::new("ERROR").header("message", "test error");
+    let err = ServerError::from_frame(frame);
+    let received = ReceivedFrame::Error(err);
+
+    let result = received.into_error();
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().message, "test error");
+}
+
+#[test]
+fn received_frame_into_error_from_frame() {
+    let frame = Frame::new("MESSAGE").header("destination", "/queue/test");
+    let received = ReceivedFrame::Frame(frame);
+
+    let result = received.into_error();
+    assert!(result.is_none());
+}
+
+#[test]
+fn received_frame_debug() {
+    let frame = Frame::new("MESSAGE").header("destination", "/queue/test");
+    let received = ReceivedFrame::Frame(frame);
+
+    let debug = format!("{:?}", received);
+    assert!(debug.contains("Frame"));
+    assert!(debug.contains("MESSAGE"));
+}
+
+#[test]
+fn received_frame_clone() {
+    let frame = Frame::new("MESSAGE")
+        .header("destination", "/queue/test")
+        .set_body(b"data".to_vec());
+    let received1 = ReceivedFrame::Frame(frame);
+    let received2 = received1.clone();
+
+    assert_eq!(received1, received2);
+}
+
+#[test]
+fn received_frame_eq_frames() {
+    let frame1 = Frame::new("MESSAGE").header("destination", "/queue/test");
+    let frame2 = Frame::new("MESSAGE").header("destination", "/queue/test");
+
+    let received1 = ReceivedFrame::Frame(frame1);
+    let received2 = ReceivedFrame::Frame(frame2);
+
+    assert_eq!(received1, received2);
+}
+
+#[test]
+fn received_frame_eq_errors() {
+    let frame1 = Frame::new("ERROR").header("message", "test");
+    let frame2 = Frame::new("ERROR").header("message", "test");
+
+    let received1 = ReceivedFrame::Error(ServerError::from_frame(frame1));
+    let received2 = ReceivedFrame::Error(ServerError::from_frame(frame2));
+
+    assert_eq!(received1, received2);
+}
+
+#[test]
+fn received_frame_ne_different_types() {
+    let msg_frame = Frame::new("MESSAGE").header("destination", "/queue/test");
+    let err_frame = Frame::new("ERROR").header("message", "test");
+
+    let received1 = ReceivedFrame::Frame(msg_frame);
+    let received2 = ReceivedFrame::Error(ServerError::from_frame(err_frame));
+
+    assert_ne!(received1, received2);
+}
+
+// ============================================================================
+// Pattern matching tests (ergonomics)
+// ============================================================================
+
+#[test]
+fn pattern_match_frame() {
+    let frame = Frame::new("MESSAGE")
+        .header("destination", "/queue/test")
+        .set_body(b"hello".to_vec());
+    let received = ReceivedFrame::Frame(frame);
+
+    match received {
+        ReceivedFrame::Frame(f) => {
+            assert_eq!(f.command, "MESSAGE");
+            assert_eq!(f.get_header("destination"), Some("/queue/test"));
+        }
+        ReceivedFrame::Error(_) => panic!("Expected Frame, got Error"),
+    }
+}
+
+#[test]
+fn pattern_match_error() {
+    let frame = Frame::new("ERROR")
+        .header("message", "authentication failed")
+        .set_body(b"Bad credentials".to_vec());
+    let err = ServerError::from_frame(frame);
+    let received = ReceivedFrame::Error(err);
+
+    match received {
+        ReceivedFrame::Frame(_) => panic!("Expected Error, got Frame"),
+        ReceivedFrame::Error(e) => {
+            assert_eq!(e.message, "authentication failed");
+            assert_eq!(e.body, Some("Bad credentials".to_string()));
+        }
+    }
+}
+
+// ============================================================================
+// Binary body handling
+// ============================================================================
+
+#[test]
+fn server_error_binary_body_returns_none() {
+    // If the body contains invalid UTF-8, body should be None
+    let frame = Frame::new("ERROR")
+        .header("message", "binary error")
+        .set_body(vec![0xFF, 0xFE, 0x00, 0x01]); // Invalid UTF-8
+
+    let err = ServerError::from_frame(frame);
+
+    assert_eq!(err.message, "binary error");
+    assert!(err.body.is_none()); // Can't convert to string
+}


### PR DESCRIPTION
## Summary

- Adds `ReceivedFrame` enum distinguishing normal frames from server errors
- Adds `ServerError` struct with parsed fields: `message`, `body`, `receipt_id`, and original frame
- Changes `Connection::next_frame()` to return `Option<ReceivedFrame>` (**breaking change**)
- Implements `std::error::Error` trait for `ServerError` for ergonomic error handling
- Pattern matching enables type-safe error handling in user code

## Breaking Change

`Connection::next_frame()` return type changed from `Option<Frame>` to `Option<ReceivedFrame>`. 

Before:
```rust
if let Some(frame) = conn.next_frame().await {
    println!("{}", frame);
}
```

After:
```rust
use iridium_stomp::ReceivedFrame;

if let Some(received) = conn.next_frame().await {
    match received {
        ReceivedFrame::Frame(frame) => println!("{}", frame),
        ReceivedFrame::Error(err) => eprintln!("Server error: {}", err),
    }
}
```

## Test plan

- [x] 25 new unit tests covering ServerError, ReceivedFrame, and pattern matching
- [x] All existing tests pass (no regressions)
- [x] Clippy warnings clean
- [x] Updated quickstart example for new API
- [x] Fixed README doc examples

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)