### PR TITLE
feat: add heartbeat configuration constants and builder (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ServerError` struct with `message`, `body`, `receipt_id`, and original frame
   - `Connection::next_frame()` now returns `Option<ReceivedFrame>` (**breaking change**)
   - Pattern matching enables type-safe error handling
+- Heartbeat configuration constants and builder ([#36])
+  - `Connection::NO_HEARTBEAT` constant for disabling heartbeats
+  - `Connection::DEFAULT_HEARTBEAT` constant for 10-second intervals
+  - `Heartbeat` struct for type-safe heartbeat configuration
+  - `Heartbeat::new()`, `Heartbeat::disabled()`, `Heartbeat::from_duration()` constructors
+  - `Display` implementation for STOMP protocol format
 - `Frame::get_header()` helper method for retrieving header values
 
 ## [0.1.0] - 2025-01-14
@@ -56,4 +62,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#33]: https://github.com/bsiegfreid/iridium-stomp/issues/33
 [#34]: https://github.com/bsiegfreid/iridium-stomp/issues/34
 [#35]: https://github.com/bsiegfreid/iridium-stomp/issues/35
+[#36]: https://github.com/bsiegfreid/iridium-stomp/issues/36
 [#37]: https://github.com/bsiegfreid/iridium-stomp/pull/37

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ pub mod subscription;
 pub use codec::{StompCodec, StompItem};
 
 /// Re-export the high-level `Connection`, `AckMode`, `ConnectOptions`, `ConnError`,
-/// `ReceivedFrame`, `ServerError`, and the heartbeat helper functions.
+/// `Heartbeat`, `ReceivedFrame`, `ServerError`, and the heartbeat helper functions.
 pub use connection::{
-    AckMode, ConnError, ConnectOptions, Connection, ReceivedFrame, ServerError,
+    AckMode, ConnError, ConnectOptions, Connection, Heartbeat, ReceivedFrame, ServerError,
     negotiate_heartbeats, parse_heartbeat_header,
 };
 

--- a/tests/heartbeat_config_tests.rs
+++ b/tests/heartbeat_config_tests.rs
@@ -1,0 +1,164 @@
+//! Tests for Heartbeat configuration and Connection constants (Issue #36)
+//!
+//! These tests verify:
+//! - Heartbeat struct creation and methods
+//! - Connection::NO_HEARTBEAT and Connection::DEFAULT_HEARTBEAT constants
+//! - Display trait implementation
+//! - Default trait implementation
+
+use iridium_stomp::{Connection, Heartbeat};
+use std::time::Duration;
+
+// ============================================================================
+// Heartbeat struct tests
+// ============================================================================
+
+#[test]
+fn heartbeat_new() {
+    let hb = Heartbeat::new(5000, 10000);
+    assert_eq!(hb.send_ms, 5000);
+    assert_eq!(hb.receive_ms, 10000);
+}
+
+#[test]
+fn heartbeat_disabled() {
+    let hb = Heartbeat::disabled();
+    assert_eq!(hb.send_ms, 0);
+    assert_eq!(hb.receive_ms, 0);
+}
+
+#[test]
+fn heartbeat_default() {
+    let hb = Heartbeat::default();
+    assert_eq!(hb.send_ms, 10000);
+    assert_eq!(hb.receive_ms, 10000);
+}
+
+#[test]
+fn heartbeat_from_duration() {
+    let hb = Heartbeat::from_duration(Duration::from_secs(15));
+    assert_eq!(hb.send_ms, 15000);
+    assert_eq!(hb.receive_ms, 15000);
+}
+
+#[test]
+fn heartbeat_from_duration_millis() {
+    let hb = Heartbeat::from_duration(Duration::from_millis(7500));
+    assert_eq!(hb.send_ms, 7500);
+    assert_eq!(hb.receive_ms, 7500);
+}
+
+#[test]
+fn heartbeat_display() {
+    let hb = Heartbeat::new(5000, 10000);
+    assert_eq!(hb.to_string(), "5000,10000");
+}
+
+#[test]
+fn heartbeat_display_disabled() {
+    let hb = Heartbeat::disabled();
+    assert_eq!(hb.to_string(), "0,0");
+}
+
+#[test]
+fn heartbeat_display_default() {
+    let hb = Heartbeat::default();
+    assert_eq!(hb.to_string(), "10000,10000");
+}
+
+#[test]
+#[allow(clippy::clone_on_copy)]
+fn heartbeat_clone() {
+    // Test that Clone works even though Copy is also implemented
+    let hb1 = Heartbeat::new(5000, 10000);
+    let hb2 = hb1.clone();
+    assert_eq!(hb1, hb2);
+}
+
+#[test]
+fn heartbeat_copy() {
+    let hb1 = Heartbeat::new(5000, 10000);
+    let hb2 = hb1; // Copy
+    assert_eq!(hb1, hb2);
+}
+
+#[test]
+fn heartbeat_eq() {
+    let hb1 = Heartbeat::new(5000, 10000);
+    let hb2 = Heartbeat::new(5000, 10000);
+    assert_eq!(hb1, hb2);
+}
+
+#[test]
+fn heartbeat_ne() {
+    let hb1 = Heartbeat::new(5000, 10000);
+    let hb2 = Heartbeat::new(5000, 15000);
+    assert_ne!(hb1, hb2);
+}
+
+#[test]
+fn heartbeat_debug() {
+    let hb = Heartbeat::new(5000, 10000);
+    let debug = format!("{:?}", hb);
+    assert!(debug.contains("Heartbeat"));
+    assert!(debug.contains("5000"));
+    assert!(debug.contains("10000"));
+}
+
+// ============================================================================
+// Connection constants tests
+// ============================================================================
+
+#[test]
+fn connection_no_heartbeat_constant() {
+    assert_eq!(Connection::NO_HEARTBEAT, "0,0");
+}
+
+#[test]
+fn connection_default_heartbeat_constant() {
+    assert_eq!(Connection::DEFAULT_HEARTBEAT, "10000,10000");
+}
+
+#[test]
+fn heartbeat_disabled_matches_constant() {
+    assert_eq!(Heartbeat::disabled().to_string(), Connection::NO_HEARTBEAT);
+}
+
+#[test]
+fn heartbeat_default_matches_constant() {
+    assert_eq!(
+        Heartbeat::default().to_string(),
+        Connection::DEFAULT_HEARTBEAT
+    );
+}
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+#[test]
+fn heartbeat_zero_send_nonzero_receive() {
+    let hb = Heartbeat::new(0, 10000);
+    assert_eq!(hb.to_string(), "0,10000");
+}
+
+#[test]
+fn heartbeat_nonzero_send_zero_receive() {
+    let hb = Heartbeat::new(10000, 0);
+    assert_eq!(hb.to_string(), "10000,0");
+}
+
+#[test]
+fn heartbeat_large_values() {
+    let hb = Heartbeat::new(u32::MAX, u32::MAX);
+    assert_eq!(hb.send_ms, u32::MAX);
+    assert_eq!(hb.receive_ms, u32::MAX);
+    let display = hb.to_string();
+    assert!(display.contains(&u32::MAX.to_string()));
+}
+
+#[test]
+fn heartbeat_one_millisecond() {
+    let hb = Heartbeat::new(1, 1);
+    assert_eq!(hb.to_string(), "1,1");
+}


### PR DESCRIPTION
## Summary

- Adds `Connection::NO_HEARTBEAT` constant (`"0,0"`) for disabling heartbeats
- Adds `Connection::DEFAULT_HEARTBEAT` constant (`"10000,10000"`) for default 10-second intervals
- Adds `Heartbeat` struct for type-safe heartbeat configuration:
  - `Heartbeat::new(send_ms, receive_ms)` - custom intervals
  - `Heartbeat::disabled()` - equivalent to `"0,0"`
  - `Heartbeat::from_duration(Duration)` - symmetric intervals from Duration
  - `Display` implementation for STOMP protocol format
  - Implements `Copy`, `Clone`, `Debug`, `PartialEq`, `Eq`

## Usage Examples

```rust
use iridium_stomp::{Connection, Heartbeat};

// Using constants for common configurations
let conn = Connection::connect(addr, login, pass, Connection::DEFAULT_HEARTBEAT).await?;
let conn = Connection::connect(addr, login, pass, Connection::NO_HEARTBEAT).await?;

// Using Heartbeat struct for type-safe configuration
let hb = Heartbeat::new(5000, 10000);
let conn = Connection::connect(addr, login, pass, &hb.to_string()).await?;

// From Duration for symmetric intervals
let hb = Heartbeat::from_duration(Duration::from_secs(15));
```

## Test plan

- [x] 21 new unit tests in `tests/heartbeat_config_tests.rs`
- [x] All existing tests pass (no regressions)
- [x] Clippy warnings clean
- [x] Doc tests pass for Heartbeat struct

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)