### PR TITLE
Add initial connection retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ for both the **initial connection** and **reconnection after a drop**. This
 means your application can start before the broker is available —
 `Connection::connect` will retry until the broker comes up.
 
-Authentication and protocol errors fail immediately on the initial connection
-so that bad configuration is surfaced fast (e.g., wrong credentials return
-`ConnError::ServerRejected` without retrying).
+Authentication failures (`ConnError::ServerRejected`) fail immediately on
+the initial connection so that bad configuration is surfaced fast. Other
+handshake and protocol failures are retried with exponential backoff.
 
 **Initial connection:**
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ connection if the server stops responding.
 Subscribe to destinations with automatic resubscription on reconnect:
 
 ```rust,ignore
-use iridium_stomp::connection::AckMode;
+use iridium_stomp::AckMode;
 
 // Auto-acknowledge (server considers delivered immediately)
 let sub = conn.subscribe("/queue/events", AckMode::Auto).await?;
@@ -150,7 +150,7 @@ For broker-specific headers (durable subscriptions, selectors, etc.):
 
 ```rust,ignore
 use iridium_stomp::SubscriptionOptions;
-use iridium_stomp::connection::AckMode;
+use iridium_stomp::AckMode;
 
 let options = SubscriptionOptions {
     headers: vec![
@@ -274,15 +274,26 @@ while let Some(received) = conn.next_frame().await {
 }
 ```
 
-### Reconnection Backoff
+### Connection Retry and Reconnection Backoff
 
-When a connection drops, the library automatically reconnects with exponential
-backoff and resubscribes to all active subscriptions. The backoff behavior is
-stability-aware: it distinguishes between a long-lived connection that dropped
-(transient failure) and a connection that dies immediately after connecting
-(persistent failure).
+The library uses exponential backoff (1s → 2s → 4s → 8s → 16s → 30s cap)
+for both the **initial connection** and **reconnection after a drop**. This
+means your application can start before the broker is available —
+`Connection::connect` will retry until the broker comes up.
 
-**Stability-aware backoff:**
+Authentication and protocol errors fail immediately on the initial connection
+so that bad configuration is surfaced fast (e.g., wrong credentials return
+`ConnError::ServerRejected` without retrying).
+
+**Initial connection:**
+
+| Scenario | Behavior |
+|----------|----------|
+| Broker unreachable at startup | Retries with exponential backoff up to 30s cap |
+| Broker crashes mid-handshake | Retries with exponential backoff |
+| Bad credentials | Fails immediately (`ConnError::ServerRejected`) |
+
+**Reconnection after a drop (stability-aware):**
 
 - If the connection was alive for at least `max(current_backoff, 5)` seconds,
   it is considered stable. On disconnect, backoff resets to 1 second for a fast

--- a/docs/durable_subscriptions.md
+++ b/docs/durable_subscriptions.md
@@ -47,7 +47,7 @@ Use `SubscriptionOptions.durable_queue` to subscribe to the named queue:
 
 ```rust
 use iridium_stomp::{Connection, SubscriptionOptions};
-use iridium_stomp::connection::AckMode;
+use iridium_stomp::AckMode;
 
 let conn = Connection::connect(
     "127.0.0.1:61613",
@@ -87,7 +87,7 @@ requires two things:
 
 ```rust
 use iridium_stomp::{Connection, ConnectOptions, SubscriptionOptions};
-use iridium_stomp::connection::AckMode;
+use iridium_stomp::AckMode;
 
 let options = ConnectOptions::new()
     .client_id("my-durable-client");

--- a/docs/heartbeats.md
+++ b/docs/heartbeats.md
@@ -115,7 +115,7 @@ let options = ConnectOptions::default()
     .with_heartbeat_notify(tx);
 
 let conn = Connection::connect_with_options(
-    "127.0.0.1:61613", "guest", "guest", "10000,10000", options
+    "127.0.0.1:61613", "guest", "guest", Connection::DEFAULT_HEARTBEAT, options
 ).await?;
 
 // In another task:

--- a/docs/subscriber-guide.md
+++ b/docs/subscriber-guide.md
@@ -51,7 +51,7 @@ Multiple subscriptions are merged into a single stream using
 ```rust
 use futures::{StreamExt, stream};
 use iridium_stomp::Connection;
-use iridium_stomp::connection::AckMode;
+use iridium_stomp::AckMode;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -100,7 +100,17 @@ during the outage and resumes when the connection comes back.
 
 ---
 
-## How reconnection works (what you actually observe)
+## How connection retry and reconnection work
+
+### Initial connection
+
+`Connection::connect` retries automatically if the broker is unreachable,
+using exponential backoff (1s → 2s → 4s → … → 30s cap). This means your
+application can start before the broker is available — it will connect once
+the broker comes up. Authentication errors (`ConnError::ServerRejected`)
+fail immediately so that bad configuration is surfaced fast.
+
+### Reconnection after a drop
 
 When the connection drops:
 
@@ -214,7 +224,7 @@ your app is offline — pass the subscription name via `ConnectOptions` and
 
 ```rust
 use iridium_stomp::{Connection, ConnectOptions, SubscriptionOptions};
-use iridium_stomp::connection::AckMode;
+use iridium_stomp::AckMode;
 
 let options = ConnectOptions::new()
     .client_id("my-app-instance-1");  // required for durable subs on ActiveMQ

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -355,7 +355,7 @@ impl AckMode {
 ///     "localhost:61613",
 ///     "guest",
 ///     "guest",
-///     "10000,10000",
+///     Connection::DEFAULT_HEARTBEAT,
 ///     options,
 /// ).await?;
 /// ```
@@ -675,6 +675,11 @@ impl Connection {
     /// This is a convenience wrapper around `connect_with_options()` that uses
     /// default options (STOMP 1.2, host="/", no client-id).
     ///
+    /// If the broker is unreachable, this method retries with exponential
+    /// backoff (1s → 2s → 4s → … → 30s cap). Authentication errors
+    /// (`ConnError::ServerRejected`) fail immediately. See
+    /// [`connect_with_options`](Self::connect_with_options) for full details.
+    ///
     /// Parameters
     /// - `addr`: TCP address (host:port) of the STOMP server.
     /// - `login`: login username for STOMP `CONNECT`.
@@ -682,9 +687,10 @@ impl Connection {
     /// - `client_hb`: client's `heart-beat` header value ("cx,cy" in
     ///   milliseconds) that will be sent in the `CONNECT` frame.
     ///
-    /// Returns a `Connection` which provides `send_frame`, `next_frame`, and
-    /// `close` helpers. The detailed connection handling (I/O, heartbeats,
-    /// reconnects) runs on a background task spawned by this method.
+    /// Returns a `Connection` which provides `send`, `send_frame`,
+    /// `next_frame`, and `close` helpers. The detailed connection handling
+    /// (I/O, heartbeats, reconnects) runs on a background task spawned by
+    /// this method.
     pub async fn connect(
         addr: &str,
         login: &str,
@@ -709,13 +715,21 @@ impl Connection {
     ///   milliseconds) that will be sent in the `CONNECT` frame.
     /// - `options`: custom connection options (version, host, client-id, etc.).
     ///
+    /// # Connection Behavior
+    ///
+    /// If the broker is unreachable, the method retries with exponential
+    /// backoff (1s → 2s → 4s → … → 30s cap) — the same strategy used for
+    /// reconnection after a connection drop. This means your application can
+    /// start before the broker is available and will connect once it comes up.
+    ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - The TCP connection cannot be established (`ConnError::Io`)
+    /// Returns an error immediately (no retry) if:
     /// - The server rejects the connection, e.g., due to invalid credentials
     ///   (`ConnError::ServerRejected`)
-    /// - The server closes the connection without responding (`ConnError::Protocol`)
+    ///
+    /// All other errors (TCP refused, connection closed mid-handshake, I/O
+    /// failures) are retried with backoff.
     ///
     /// # Example
     ///
@@ -730,7 +744,7 @@ impl Connection {
     ///     "localhost:61613",
     ///     "guest",
     ///     "guest",
-    ///     "10000,10000",
+    ///     Connection::DEFAULT_HEARTBEAT,
     ///     options,
     /// ).await?;
     /// ```
@@ -763,34 +777,80 @@ impl Connection {
         let custom_headers = options.headers;
         let heartbeat_notify_tx = options.heartbeat_tx;
 
-        // Perform initial connection and STOMP handshake before spawning background task.
-        // This ensures authentication errors are returned to the caller immediately.
-        let stream = TcpStream::connect(&addr).await?;
-        let mut framed = Framed::new(stream, StompCodec::new());
+        // Perform initial connection and STOMP handshake before spawning
+        // background task. Retries with exponential backoff on I/O and
+        // protocol errors (broker unreachable or crashing mid-handshake)
+        // using the same strategy as reconnection. Only ServerRejected
+        // (authentication failure) fails immediately.
+        let mut backoff_secs: u64 = 1;
+        let (framed, send_interval, recv_interval) = loop {
+            let stream = match TcpStream::connect(&addr).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        addr = %addr,
+                        error = %e,
+                        backoff_secs,
+                        "initial connect failed, retrying in {}s",
+                        backoff_secs,
+                    );
+                    tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                    backoff_secs = (backoff_secs * 2).min(30);
+                    continue;
+                }
+            };
+            let mut framed = Framed::new(stream, StompCodec::new());
 
-        // Build and send CONNECT frame
-        let connect = Self::build_connect_frame(
-            &accept_version,
-            &host,
-            &login,
-            &passcode,
-            &client_hb,
-            &client_id,
-            &custom_headers,
-        );
+            let connect = Self::build_connect_frame(
+                &accept_version,
+                &host,
+                &login,
+                &passcode,
+                &client_hb,
+                &client_id,
+                &custom_headers,
+            );
 
-        framed
-            .send(StompItem::Frame(connect))
-            .await
-            .map_err(|e| ConnError::Io(std::io::Error::other(e)))?;
+            if framed.send(StompItem::Frame(connect)).await.is_err() {
+                tracing::warn!(
+                    addr = %addr,
+                    backoff_secs,
+                    "failed to send CONNECT frame, retrying in {}s",
+                    backoff_secs,
+                );
+                tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                backoff_secs = (backoff_secs * 2).min(30);
+                continue;
+            }
 
-        // Wait for CONNECTED or ERROR response
-        let server_heartbeat = Self::await_connected_response(&mut framed).await?;
-
-        // Calculate heartbeat intervals
-        let (cx, cy) = parse_heartbeat_header(&client_hb);
-        let (sx, sy) = parse_heartbeat_header(&server_heartbeat);
-        let (send_interval, recv_interval) = negotiate_heartbeats(cx, cy, sx, sy);
+            match Self::await_connected_response(&mut framed).await {
+                Ok(server_hb) => {
+                    tracing::info!(addr = %addr, "connected to broker");
+                    let (cx, cy) = parse_heartbeat_header(&client_hb);
+                    let (sx, sy) = parse_heartbeat_header(&server_hb);
+                    let (si, ri) = negotiate_heartbeats(cx, cy, sx, sy);
+                    break (framed, si, ri);
+                }
+                // Auth errors fail immediately — bad config should not be retried
+                Err(e @ ConnError::ServerRejected(_)) => {
+                    return Err(e);
+                }
+                // I/O and protocol errors during handshake (e.g., broker
+                // crashed or closed mid-handshake) — retry with backoff
+                Err(e) => {
+                    tracing::warn!(
+                        addr = %addr,
+                        error = %e,
+                        backoff_secs,
+                        "handshake failed, retrying in {}s",
+                        backoff_secs,
+                    );
+                    tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                    backoff_secs = (backoff_secs * 2).min(30);
+                    continue;
+                }
+            }
+        };
 
         // Now spawn background task for ongoing I/O and reconnection
         let shutdown_tx_clone = shutdown_tx.clone();
@@ -844,14 +904,20 @@ impl Connection {
                             );
 
                             if framed.send(StompItem::Frame(connect)).await.is_err() {
+                                tracing::warn!(
+                                    addr = %addr,
+                                    backoff_secs,
+                                    "reconnect: failed to send CONNECT frame, retrying in {}s",
+                                    backoff_secs,
+                                );
                                 tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                                 backoff_secs = (backoff_secs * 2).min(30);
                                 continue;
                             }
 
-                            // Wait for CONNECTED (on reconnect, silently retry on ERROR)
                             match Self::await_connected_response(&mut framed).await {
                                 Ok(server_hb) => {
+                                    tracing::info!(addr = %addr, "reconnected to broker");
                                     let (cx, cy) = parse_heartbeat_header(&client_hb);
                                     let (sx, sy) = parse_heartbeat_header(&server_hb);
                                     let (si, ri) = negotiate_heartbeats(cx, cy, sx, sy);
@@ -859,15 +925,28 @@ impl Connection {
                                     current_recv_interval = ri;
                                     framed
                                 }
-                                Err(_) => {
-                                    // Reconnect failed (auth error or other), retry with backoff
+                                Err(e) => {
+                                    tracing::warn!(
+                                        addr = %addr,
+                                        error = %e,
+                                        backoff_secs,
+                                        "reconnect: handshake failed, retrying in {}s",
+                                        backoff_secs,
+                                    );
                                     tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                                     backoff_secs = (backoff_secs * 2).min(30);
                                     continue;
                                 }
                             }
                         }
-                        Err(_) => {
+                        Err(e) => {
+                            tracing::warn!(
+                                addr = %addr,
+                                error = %e,
+                                backoff_secs,
+                                "reconnect: broker unreachable, retrying in {}s",
+                                backoff_secs,
+                            );
                             tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                             backoff_secs = (backoff_secs * 2).min(30);
                             continue;
@@ -1136,12 +1215,25 @@ impl Connection {
                 if shutdown_sub.try_recv().is_ok() {
                     break;
                 }
-                if conn_start.elapsed() >= Duration::from_secs(backoff_secs.max(5)) {
+                let stable_duration = conn_start.elapsed();
+                if stable_duration >= Duration::from_secs(backoff_secs.max(5)) {
                     // Connection was stable — reset backoff
                     backoff_secs = 1;
+                    tracing::info!(
+                        addr = %addr,
+                        stable_secs = stable_duration.as_secs(),
+                        "connection dropped after stable session, reconnecting in 1s",
+                    );
                 } else {
                     // Connection died quickly — increase backoff
                     backoff_secs = (backoff_secs * 2).min(30);
+                    tracing::warn!(
+                        addr = %addr,
+                        stable_secs = stable_duration.as_secs(),
+                        backoff_secs,
+                        "connection dropped quickly, reconnecting in {}s",
+                        backoff_secs,
+                    );
                 }
                 tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -811,9 +811,10 @@ impl Connection {
                 &custom_headers,
             );
 
-            if framed.send(StompItem::Frame(connect)).await.is_err() {
+            if let Err(e) = framed.send(StompItem::Frame(connect)).await {
                 tracing::warn!(
                     addr = %addr,
+                    error = %e,
                     backoff_secs,
                     "failed to send CONNECT frame, retrying in {}s",
                     backoff_secs,
@@ -903,9 +904,10 @@ impl Connection {
                                 &custom_headers,
                             );
 
-                            if framed.send(StompItem::Frame(connect)).await.is_err() {
+                            if let Err(e) = framed.send(StompItem::Frame(connect)).await {
                                 tracing::warn!(
                                     addr = %addr,
+                                    error = %e,
                                     backoff_secs,
                                     "reconnect: failed to send CONNECT frame, retrying in {}s",
                                     backoff_secs,

--- a/tests/connect_error_tests.rs
+++ b/tests/connect_error_tests.rs
@@ -74,16 +74,21 @@ async fn connect_closed_before_connected_retries() {
 
     // Spawn a mock server that closes immediately after receiving CONNECT
     let server_addr = addr.clone();
-    thread::spawn(move || {
+    let server = thread::spawn(move || {
         let listener = TcpListener::bind(&server_addr).unwrap();
-        listener.set_nonblocking(false).unwrap();
-
-        // Accept and close twice so the client can retry
-        for _ in 0..2 {
-            if let Ok((mut stream, _)) = listener.accept() {
-                let mut buf = [0u8; 1024];
-                let _ = stream.read(&mut buf);
-                drop(stream);
+        listener.set_nonblocking(true).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut buf = [0u8; 1024];
+                    let _ = stream.read(&mut buf);
+                    drop(stream);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(_) => break,
             }
         }
     });
@@ -102,6 +107,8 @@ async fn connect_closed_before_connected_retries() {
         result.is_err(),
         "Expected connect to keep retrying when server closes during handshake"
     );
+
+    let _ = server.join();
 }
 
 /// Test that connection refused retries (does not fail immediately).

--- a/tests/connect_error_tests.rs
+++ b/tests/connect_error_tests.rs
@@ -65,69 +65,65 @@ async fn connect_error_frame_returns_server_rejected() {
     server.join().unwrap();
 }
 
-/// Test that server closing connection before CONNECTED returns Protocol error
+/// Test that server closing connection before CONNECTED causes a retry
+/// (not an immediate failure). Protocol errors during handshake are transient.
 #[tokio::test]
-async fn connect_closed_before_connected_returns_protocol_error() {
+async fn connect_closed_before_connected_retries() {
     let port = get_available_port();
     let addr = format!("127.0.0.1:{}", port);
 
     // Spawn a mock server that closes immediately after receiving CONNECT
     let server_addr = addr.clone();
-    let server = thread::spawn(move || {
+    thread::spawn(move || {
         let listener = TcpListener::bind(&server_addr).unwrap();
         listener.set_nonblocking(false).unwrap();
 
-        if let Ok((mut stream, _)) = listener.accept() {
-            // Read the CONNECT frame
-            let mut buf = [0u8; 1024];
-            let _ = stream.read(&mut buf);
-
-            // Close without sending CONNECTED
-            drop(stream);
+        // Accept and close twice so the client can retry
+        for _ in 0..2 {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                drop(stream);
+            }
         }
     });
 
     // Give server time to start
     thread::sleep(Duration::from_millis(50));
 
-    // Attempt connection
-    let result = Connection::connect(&addr, "user", "pass", "0,0").await;
+    // Should keep retrying, not return an error
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        Connection::connect(&addr, "user", "pass", "0,0"),
+    )
+    .await;
 
-    // Should get Protocol error about connection closed
-    match result {
-        Err(ConnError::Protocol(msg)) => {
-            assert!(
-                msg.contains("closed") || msg.contains("CONNECTED"),
-                "Expected message about connection closed, got: {}",
-                msg
-            );
-        }
-        Err(ConnError::Io(_)) => {
-            // Also acceptable - connection reset
-        }
-        Err(other) => panic!("Expected Protocol or Io error, got: {:?}", other),
-        Ok(_) => panic!("Expected error, got successful connection"),
-    }
-
-    server.join().unwrap();
+    assert!(
+        result.is_err(),
+        "Expected connect to keep retrying when server closes during handshake"
+    );
 }
 
-/// Test that connection refused returns Io error
+/// Test that connection refused retries (does not fail immediately).
+///
+/// With initial connection retry, an unreachable broker causes `connect` to
+/// retry with backoff. We verify it does *not* return within a short window,
+/// then cancel the attempt.
 #[tokio::test]
-async fn connect_refused_returns_io_error() {
-    // Use a port that nothing is listening on
+async fn connect_refused_retries_instead_of_failing() {
     let port = get_available_port();
     let addr = format!("127.0.0.1:{}", port);
 
-    // Don't start any server - port should be closed
+    // No server listening — connect should retry, not return an error.
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        Connection::connect(&addr, "user", "pass", "0,0"),
+    )
+    .await;
 
-    let result = Connection::connect(&addr, "user", "pass", "0,0").await;
-
-    match result {
-        Err(ConnError::Io(err)) => {
-            assert_eq!(err.kind(), std::io::ErrorKind::ConnectionRefused);
-        }
-        Err(other) => panic!("Expected Io error, got: {:?}", other),
-        Ok(_) => panic!("Expected error, got successful connection"),
-    }
+    // Timeout means connect is still retrying — expected behaviour.
+    assert!(
+        result.is_err(),
+        "Expected connect to keep retrying, but it returned"
+    );
 }

--- a/tests/connect_error_tests.rs
+++ b/tests/connect_error_tests.rs
@@ -108,7 +108,7 @@ async fn connect_closed_before_connected_retries() {
         "Expected connect to keep retrying when server closes during handshake"
     );
 
-    let _ = server.join();
+    server.join().unwrap();
 }
 
 /// Test that connection refused retries (does not fail immediately).

--- a/tests/connect_retry_tests.rs
+++ b/tests/connect_retry_tests.rs
@@ -32,7 +32,7 @@ async fn connect_succeeds_after_broker_starts_late() {
 
     // Start a mock STOMP server after a delay
     let server_addr = addr.clone();
-    thread::spawn(move || {
+    let server = thread::spawn(move || {
         // Wait so the client hits at least one retry
         thread::sleep(Duration::from_secs(2));
 
@@ -69,6 +69,7 @@ async fn connect_succeeds_after_broker_starts_late() {
     );
 
     conn.unwrap().close().await;
+    server.join().unwrap();
 }
 
 /// Bad credentials fail immediately — no retry.
@@ -156,7 +157,7 @@ async fn connect_retries_on_server_close_during_handshake() {
         "Expected connect to keep retrying on protocol error, but it returned"
     );
 
-    let _ = server.join();
+    server.join().unwrap();
 }
 
 /// Verify backoff increases between retries.
@@ -193,7 +194,7 @@ async fn connect_retry_then_auth_error_fails_fast() {
     let addr = format!("127.0.0.1:{}", port);
 
     let server_addr = addr.clone();
-    thread::spawn(move || {
+    let server = thread::spawn(move || {
         // Delay so client hits at least one TCP retry
         thread::sleep(Duration::from_millis(1500));
 
@@ -235,6 +236,8 @@ async fn connect_retry_then_auth_error_fails_fast() {
         "unexpected timing: {:?}",
         elapsed
     );
+
+    server.join().unwrap();
 }
 
 /// Multiple retry attempts actually happen (counted by a mock server).

--- a/tests/connect_retry_tests.rs
+++ b/tests/connect_retry_tests.rs
@@ -1,0 +1,284 @@
+//! Tests for initial connection retry with exponential backoff.
+//!
+//! These tests verify that `Connection::connect` retries on I/O errors
+//! (broker unreachable) and fails immediately on authentication / protocol
+//! errors.
+
+use iridium_stomp::Connection;
+use iridium_stomp::connection::ConnError;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Helper to find an available port.
+fn get_available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Broker comes up after a delay — connect should succeed after retrying.
+#[tokio::test]
+async fn connect_succeeds_after_broker_starts_late() {
+    let port = get_available_port();
+    let addr = format!("127.0.0.1:{}", port);
+
+    // Start a mock STOMP server after a delay
+    let server_addr = addr.clone();
+    thread::spawn(move || {
+        // Wait so the client hits at least one retry
+        thread::sleep(Duration::from_secs(2));
+
+        let listener = TcpListener::bind(&server_addr).unwrap();
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+
+            let connected = "CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0";
+            stream.write_all(connected.as_bytes()).unwrap();
+            stream.flush().unwrap();
+
+            // Keep alive so the connection doesn't drop immediately
+            thread::sleep(Duration::from_secs(1));
+        }
+    });
+
+    let start = Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        Connection::connect(&addr, "guest", "guest", "0,0"),
+    )
+    .await;
+
+    let elapsed = start.elapsed();
+    assert!(result.is_ok(), "connect should not have timed out");
+
+    let conn = result.unwrap();
+    assert!(conn.is_ok(), "connect should have succeeded");
+    assert!(
+        elapsed >= Duration::from_secs(2),
+        "should have waited for the broker to start (elapsed: {:?})",
+        elapsed
+    );
+
+    conn.unwrap().close().await;
+}
+
+/// Bad credentials fail immediately — no retry.
+#[tokio::test]
+async fn connect_fails_immediately_on_auth_error() {
+    let port = get_available_port();
+    let addr = format!("127.0.0.1:{}", port);
+
+    let server_addr = addr.clone();
+    let server = thread::spawn(move || {
+        let listener = TcpListener::bind(&server_addr).unwrap();
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+
+            let error = "ERROR\nmessage:Bad credentials\n\nAccess refused\0";
+            stream.write_all(error.as_bytes()).unwrap();
+            stream.flush().unwrap();
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    thread::sleep(Duration::from_millis(50));
+
+    let start = Instant::now();
+    let result = Connection::connect(&addr, "bad", "creds", "0,0").await;
+    let elapsed = start.elapsed();
+
+    match result {
+        Err(ConnError::ServerRejected(err)) => {
+            assert_eq!(err.message, "Bad credentials");
+        }
+        Err(other) => panic!("Expected ServerRejected, got: {}", other),
+        Ok(_) => panic!("Expected ServerRejected, got successful connection"),
+    }
+
+    // Should have failed fast — well under the 1s first backoff
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "auth error should fail immediately, took {:?}",
+        elapsed
+    );
+
+    server.join().unwrap();
+}
+
+/// Server closes without CONNECTED — this is retried (could be a transient
+/// broker crash), not a fast failure.
+#[tokio::test]
+async fn connect_retries_on_server_close_during_handshake() {
+    let port = get_available_port();
+    let addr = format!("127.0.0.1:{}", port);
+
+    let server_addr = addr.clone();
+    thread::spawn(move || {
+        let listener = TcpListener::bind(&server_addr).unwrap();
+        // Accept two connections and close both without responding
+        for _ in 0..2 {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                drop(stream);
+            }
+        }
+    });
+
+    thread::sleep(Duration::from_millis(50));
+
+    // Should keep retrying, not fail immediately
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        Connection::connect(&addr, "guest", "guest", "0,0"),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Expected connect to keep retrying on protocol error, but it returned"
+    );
+}
+
+/// Verify backoff increases between retries.
+///
+/// A mock server that rejects TCP connections is simulated by not listening.
+/// We use a timeout to observe that connect is still retrying, and check that
+/// successive retry intervals grow.
+#[tokio::test]
+async fn connect_retry_uses_exponential_backoff() {
+    let port = get_available_port();
+    let addr = format!("127.0.0.1:{}", port);
+
+    // No server — every TCP connect will fail and be retried.
+    // The first retry is after 1s, second after 2s, so after 3.5s we should
+    // still be retrying (total: 1 + 2 = 3s of sleep plus attempt time).
+    let result = tokio::time::timeout(
+        Duration::from_millis(3500),
+        Connection::connect(&addr, "guest", "guest", "0,0"),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "connect should still be retrying after 3.5s (1s + 2s backoff)"
+    );
+}
+
+/// Broker is initially unreachable, then starts accepting but sends an auth
+/// error. The retry loop should surface the auth error immediately once the
+/// broker is reachable.
+#[tokio::test]
+async fn connect_retry_then_auth_error_fails_fast() {
+    let port = get_available_port();
+    let addr = format!("127.0.0.1:{}", port);
+
+    let server_addr = addr.clone();
+    thread::spawn(move || {
+        // Delay so client hits at least one TCP retry
+        thread::sleep(Duration::from_millis(1500));
+
+        let listener = TcpListener::bind(&server_addr).unwrap();
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+
+            let error = "ERROR\nmessage:Access denied\n\n\0";
+            stream.write_all(error.as_bytes()).unwrap();
+            stream.flush().unwrap();
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    let start = Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        Connection::connect(&addr, "bad", "creds", "0,0"),
+    )
+    .await;
+
+    let elapsed = start.elapsed();
+
+    // Should have returned (not timed out)
+    assert!(result.is_ok(), "should not time out");
+
+    match result.unwrap() {
+        Err(ConnError::ServerRejected(err)) => {
+            assert_eq!(err.message, "Access denied");
+        }
+        Err(other) => panic!("Expected ServerRejected, got: {}", other),
+        Ok(_) => panic!("Expected ServerRejected, got successful connection"),
+    }
+
+    // Took at least 1.5s (waiting for broker) but not much more
+    assert!(
+        elapsed >= Duration::from_millis(1500) && elapsed < Duration::from_secs(5),
+        "unexpected timing: {:?}",
+        elapsed
+    );
+}
+
+/// Multiple retry attempts actually happen (counted by a mock server).
+#[tokio::test]
+async fn connect_retry_makes_multiple_attempts() {
+    let port = get_available_port();
+    let addr = format!("127.0.0.1:{}", port);
+    let attempt_count = Arc::new(AtomicU32::new(0));
+
+    // Mock server that accepts connections but immediately closes them,
+    // causing I/O errors during the STOMP handshake. On the 3rd attempt
+    // it responds with CONNECTED.
+    let server_addr = addr.clone();
+    let count = attempt_count.clone();
+    let server = thread::spawn(move || {
+        let listener = TcpListener::bind(&server_addr).unwrap();
+        for _ in 0..3 {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+
+                if n < 3 {
+                    // Close without responding — triggers I/O retry
+                    drop(stream);
+                } else {
+                    // Third attempt — send CONNECTED
+                    let connected = "CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0";
+                    stream.write_all(connected.as_bytes()).unwrap();
+                    stream.flush().unwrap();
+                    thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    });
+
+    thread::sleep(Duration::from_millis(50));
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        Connection::connect(&addr, "guest", "guest", "0,0"),
+    )
+    .await;
+
+    assert!(result.is_ok(), "should not time out");
+    let conn = result.unwrap();
+    assert!(conn.is_ok(), "should connect on third attempt");
+
+    let attempts = attempt_count.load(Ordering::SeqCst);
+    assert_eq!(
+        attempts, 3,
+        "expected 3 connection attempts, got {}",
+        attempts
+    );
+
+    conn.unwrap().close().await;
+    server.join().unwrap();
+}

--- a/tests/connect_retry_tests.rs
+++ b/tests/connect_retry_tests.rs
@@ -1,8 +1,10 @@
 //! Tests for initial connection retry with exponential backoff.
 //!
-//! These tests verify that `Connection::connect` retries on I/O errors
-//! (broker unreachable) and fails immediately on authentication / protocol
-//! errors.
+//! These tests verify that `Connection::connect` retries on I/O and
+//! handshake failures that may be transient (for example, broker unreachable
+//! or the server closing during the handshake), and fails immediately only
+//! when the server explicitly rejects the connection
+//! (`ConnError::ServerRejected`).
 
 use iridium_stomp::Connection;
 use iridium_stomp::connection::ConnError;
@@ -103,10 +105,10 @@ async fn connect_fails_immediately_on_auth_error() {
         Ok(_) => panic!("Expected ServerRejected, got successful connection"),
     }
 
-    // Should have failed fast — well under the 1s first backoff
+    // Should have failed fast — before the 1s first backoff
     assert!(
-        elapsed < Duration::from_millis(500),
-        "auth error should fail immediately, took {:?}",
+        elapsed < Duration::from_secs(1),
+        "auth error should fail before retry backoff, took {:?}",
         elapsed
     );
 
@@ -121,14 +123,21 @@ async fn connect_retries_on_server_close_during_handshake() {
     let addr = format!("127.0.0.1:{}", port);
 
     let server_addr = addr.clone();
-    thread::spawn(move || {
+    let server = thread::spawn(move || {
         let listener = TcpListener::bind(&server_addr).unwrap();
-        // Accept two connections and close both without responding
-        for _ in 0..2 {
-            if let Ok((mut stream, _)) = listener.accept() {
-                let mut buf = [0u8; 1024];
-                let _ = stream.read(&mut buf);
-                drop(stream);
+        listener.set_nonblocking(true).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut buf = [0u8; 1024];
+                    let _ = stream.read(&mut buf);
+                    drop(stream);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(_) => break,
             }
         }
     });
@@ -146,6 +155,8 @@ async fn connect_retries_on_server_close_during_handshake() {
         result.is_err(),
         "Expected connect to keep retrying on protocol error, but it returned"
     );
+
+    let _ = server.join();
 }
 
 /// Verify backoff increases between retries.


### PR DESCRIPTION
This pull request significantly improves the initial connection and reconnection logic for the STOMP client, making connection behavior more robust and user-friendly. The main changes are: the initial connection now uses the same exponential backoff and stability-aware retry strategy as reconnections, with immediate failure for authentication errors. Documentation and tests are updated to reflect and verify these behaviors, and additional logging is added for better observability.

**Connection Retry and Backoff Improvements:**

- The initial connection (`Connection::connect` and `connect_with_options`) now retries with exponential backoff (1s → 2s → 4s → … → 30s cap) if the broker is unreachable, matching the reconnection strategy. Authentication errors (`ConnError::ServerRejected`) still fail immediately, surfacing misconfiguration quickly. [[1]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afR678-R693) [[2]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL766-L771) [[3]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL782-R853)
- Enhanced stability-aware backoff for reconnections, with improved logging to indicate whether a connection was stable or dropped quickly, and to track retry intervals. [[1]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL1139-R1236) [[2]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afR907-R949)

**Documentation Updates:**

- Updated the README and guide docs to clearly explain the new connection retry and reconnection behavior, including tables and scenarios for initial connection and reconnection, and updated code examples to use the new API and constants. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L277-R296) [[2]](diffhunk://#diff-a6c9d02c4672cef19b00ddacc14a68432eed6599febbbc8f382d802e8d5b46c1L103-R113) [[3]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL358-R358) [[4]](diffhunk://#diff-179ab51c091416e4ed6cbdc7c43a3116ad4a39775047269bdd8449a8061c907cL118-R118)
- Simplified import statements in documentation and examples to reflect the new `AckMode` location. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R137) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R153) [[3]](diffhunk://#diff-867ee617115150b9c40dbc5285d18e4e8096e050cb129770297a0ee4b0fc35c2L50-R50) [[4]](diffhunk://#diff-867ee617115150b9c40dbc5285d18e4e8096e050cb129770297a0ee4b0fc35c2L90-R90) [[5]](diffhunk://#diff-a6c9d02c4672cef19b00ddacc14a68432eed6599febbbc8f382d802e8d5b46c1L54-R54) [[6]](diffhunk://#diff-a6c9d02c4672cef19b00ddacc14a68432eed6599febbbc8f382d802e8d5b46c1L217-R227)

**Testing Improvements:**

- Updated and expanded tests to verify that initial connection failures (e.g., broker unreachable, server closes during handshake) now retry instead of failing immediately, using timeouts to ensure correct retry behavior.

These changes make the client more resilient in production environments, especially during broker outages or startups.