### PR TITLE
Stop Resubscribe on First Connection Error

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -994,7 +994,7 @@ impl Connection {
                         }
                         v
                     };
-    
+
                     for (dest, id, ack, headers) in subs_snapshot {
                         let mut sf = Frame::new("SUBSCRIBE");
                         sf = sf

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -865,7 +865,6 @@ impl Connection {
             let mut current_send_interval = send_interval;
             let mut current_recv_interval = recv_interval;
             let mut first_iteration = true;
-            
             // Track subscription errors across reconnections. If a subscription
             // receives too many consecutive errors, we remove it to prevent
             // error loops (e.g., Artemis sending repeated permission errors).
@@ -977,10 +976,9 @@ impl Connection {
                 // Resubscribe any existing subscriptions after reconnect.
                 // We snapshot the subscription entries while holding the lock
                 // and then issue SUBSCRIBE frames using the sink.
-                if first_iteration{
+                if first_iteration {
                     first_iteration = false;
-                }
-                else{
+                } else {
                     let subs_snapshot: Vec<ResubEntry> = {
                         let map = subscriptions.lock().await;
                         let mut v: Vec<ResubEntry> = Vec::new();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -864,7 +864,8 @@ impl Connection {
             let mut current_framed = Some(framed);
             let mut current_send_interval = send_interval;
             let mut current_recv_interval = recv_interval;
-
+            let mut first_iteration = true;
+            
             // Track subscription errors across reconnections. If a subscription
             // receives too many consecutive errors, we remove it to prevent
             // error loops (e.g., Artemis sending repeated permission errors).
@@ -976,34 +977,38 @@ impl Connection {
                 // Resubscribe any existing subscriptions after reconnect.
                 // We snapshot the subscription entries while holding the lock
                 // and then issue SUBSCRIBE frames using the sink.
-                let subs_snapshot: Vec<ResubEntry> = {
-                    let map = subscriptions.lock().await;
-                    let mut v: Vec<ResubEntry> = Vec::new();
-                    for (dest, vec) in map.iter() {
-                        for entry in vec.iter() {
-                            v.push((
-                                dest.clone(),
-                                entry.id.clone(),
-                                entry.ack.clone(),
-                                entry.headers.clone(),
-                            ));
-                        }
-                    }
-                    v
-                };
-
-                for (dest, id, ack, headers) in subs_snapshot {
-                    let mut sf = Frame::new("SUBSCRIBE");
-                    sf = sf
-                        .header("id", &id)
-                        .header("destination", &dest)
-                        .header("ack", &ack);
-                    for (k, v) in headers {
-                        sf = sf.header(&k, &v);
-                    }
-                    let _ = sink.send(StompItem::Frame(sf)).await;
+                if first_iteration{
+                    first_iteration = false;
                 }
-
+                else{
+                    let subs_snapshot: Vec<ResubEntry> = {
+                        let map = subscriptions.lock().await;
+                        let mut v: Vec<ResubEntry> = Vec::new();
+                        for (dest, vec) in map.iter() {
+                            for entry in vec.iter() {
+                                v.push((
+                                    dest.clone(),
+                                    entry.id.clone(),
+                                    entry.ack.clone(),
+                                    entry.headers.clone(),
+                                ));
+                            }
+                        }
+                        v
+                    };
+    
+                    for (dest, id, ack, headers) in subs_snapshot {
+                        let mut sf = Frame::new("SUBSCRIBE");
+                        sf = sf
+                            .header("id", &id)
+                            .header("destination", &dest)
+                            .header("ack", &ack);
+                        for (k, v) in headers {
+                            sf = sf.header(&k, &v);
+                        }
+                        let _ = sink.send(StompItem::Frame(sf)).await;
+                    }
+                }
                 let mut hb_tick = match send_interval {
                     Some(d) => tokio::time::interval(d),
                     None => tokio::time::interval(Duration::from_secs(86400)),


### PR DESCRIPTION
Was using this library to create publishers and subscribers to connect to an activemq broker and noticed an error in which subscribers would receive exact messages twice even though messages were published once. Error was isolated to the fact that when there was a subscription, the connection function would try to resubscribe to the same topic with the same sub-id leading to duplicate subscriptions. To solve this error, I added functionality to only allow resubscription if it is not the first iteration of connection as this makes sure there is no auto-resubscribe causing issues with ActiveMQ Classic.