### PR TITLE
Restore 100% rustdoc coverage and fix clippy lint

### DIFF
--- a/src/bin/cli/state.rs
+++ b/src/bin/cli/state.rs
@@ -325,7 +325,7 @@ impl AppState {
 
         // Sort destinations by message count (descending)
         let mut subs: Vec<_> = self.subscriptions.iter().collect();
-        subs.sort_by(|a, b| b.1.message_count.cmp(&a.1.message_count));
+        subs.sort_by_key(|b| std::cmp::Reverse(b.1.message_count));
 
         let max_dest_len = subs
             .iter()

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -54,6 +54,7 @@ pub struct StompCodec {
 }
 
 impl StompCodec {
+    /// Create a new `StompCodec` instance.
     pub fn new() -> Self {
         Self {}
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -306,8 +306,13 @@ impl ReceivedFrame {
 /// Subscription acknowledgement modes as defined by STOMP 1.2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AckMode {
+    /// Server considers the message delivered as soon as it is sent (no
+    /// explicit acknowledgement required from the client).
     Auto,
+    /// Client must send an ACK frame; the ACK is cumulative — it
+    /// acknowledges all messages up to and including the specified one.
     Client,
+    /// Client must send an ACK frame for each individual message.
     ClientIndividual,
 }
 
@@ -1347,6 +1352,11 @@ impl Connection {
         self.send_frame(frame).await
     }
 
+    /// Send an arbitrary STOMP frame to the broker.
+    ///
+    /// Use this when you need full control over the frame (custom headers,
+    /// binary body, receipt requests, etc.). For simple text messages, prefer
+    /// [`send`](Self::send).
     pub async fn send_frame(&self, frame: Frame) -> Result<(), ConnError> {
         // Send a frame to the background writer task.
         //
@@ -1865,6 +1875,9 @@ impl Connection {
         }
     }
 
+    /// Gracefully shut down the connection.
+    ///
+    /// Signals the background task to stop and drops the connection handle.
     pub async fn close(self) {
         // Signal the background task to shutdown by broadcasting on the
         // shutdown channel. Consumers may await task termination separately

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,15 @@
 //! Additional user-facing guides from the `docs/` directory are exposed as
 //! rustdoc modules so they appear on docs.rs. See the `subscriptions_docs`
 //! module for information about durable subscriptions and `SubscriptionOptions`.
+/// STOMP wire-protocol codec for use with `tokio_util::codec::Framed`.
 pub mod codec;
+/// Connection lifecycle, retry, reconnection, and the main `Connection` API.
 pub mod connection;
+/// STOMP frame representation (command, headers, body).
 pub mod frame;
+/// Low-level STOMP frame parser (byte-level decoding).
 pub mod parser;
+/// Subscription handles and configuration types.
 pub mod subscription;
 
 /// Re-export the codec types (`StompCodec`, `StompItem`) for easy use with


### PR DESCRIPTION
## Summary
- Adds doc comments to close rustdoc coverage gaps: `AckMode::{Auto, Client, ClientIndividual}`, `Connection::send_frame`, `Connection::close`, `StompCodec::new`, and the five `pub mod` declarations in `src/lib.rs`. Total coverage back to 100% (96/96 items).
- Applies clippy's `unnecessary_sort_by` suggestion in `src/bin/cli/state.rs` — `sort_by` closure replaced with `sort_by_key` using `std::cmp::Reverse`. New lint introduced in clippy 1.95; was blocking `cargo clippy --all-targets --all-features -- -D warnings`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 18/18 pass
- [x] `RUSTDOCFLAGS="-Z unstable-options --show-coverage" cargo +nightly doc --no-deps` — 100% across all files