### PR TITLE
Log resubscribe send failures instead of silently swallowing

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1009,7 +1009,14 @@ impl Connection {
                         for (k, v) in headers {
                             sf = sf.header(&k, &v);
                         }
-                        let _ = sink.send(StompItem::Frame(sf)).await;
+                        if let Err(e) = sink.send(StompItem::Frame(sf)).await {
+                            tracing::warn!(
+                                destination = %dest,
+                                subscription_id = %id,
+                                error = %e,
+                                "failed to resubscribe after reconnect",
+                            );
+                        }
                     }
                 }
                 let mut hb_tick = match send_interval {


### PR DESCRIPTION
Fixes #48.

## Summary
- The resubscribe-after-reconnect loop in `src/connection.rs` previously discarded `sink.send(...)` errors with `let _ = ...`, meaning a failed resubscription would leave a subscriber silently inert after a reconnect with no signal that anything was wrong.
- Replaced with a `tracing::warn!` that surfaces the destination, subscription id, and underlying error — matching the structured-logging style used elsewhere in this file (e.g., the CONNECT/handshake failure warnings).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 18/18 pass
- [x] `RUSTDOCFLAGS="-Z unstable-options --show-coverage" cargo +nightly doc --no-deps` — 100% (96/96)