### PR TITLE
fix: make header lookup case-insensitive

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -76,12 +76,12 @@ impl Frame {
 
     /// Get the value of a header by name.
     ///
-    /// Returns the first header value matching the given key (case-sensitive),
+    /// Returns the first header value matching the given key (case-insensitive),
     /// or `None` if no such header exists.
     pub fn get_header(&self, key: &str) -> Option<&str> {
         self.headers
             .iter()
-            .find(|(k, _)| k == key)
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
             .map(|(_, v)| v.as_str())
     }
 }

--- a/tests/frame_unit.rs
+++ b/tests/frame_unit.rs
@@ -259,6 +259,26 @@ fn frame_duplicate_headers() {
 }
 
 #[test]
+fn frame_get_header_is_case_insensitive() {
+    let frame = Frame::new("MESSAGE")
+        .header("Message-Id", "msg-123")
+        .header("Subscription", "sub-1");
+
+    assert_eq!(frame.get_header("message-id"), Some("msg-123"));
+    assert_eq!(frame.get_header("MESSAGE-ID"), Some("msg-123"));
+    assert_eq!(frame.get_header("subscription"), Some("sub-1"));
+}
+
+#[test]
+fn frame_get_header_returns_first_case_insensitive_match() {
+    let frame = Frame::new("MESSAGE")
+        .header("Message-Id", "first")
+        .header("message-id", "second");
+
+    assert_eq!(frame.get_header("MESSAGE-ID"), Some("first"));
+}
+
+#[test]
 fn frame_header_special_characters() {
     let frame =
         Frame::new("SEND").header("url", "http://example.com:8080/path?query=value&other=123");


### PR DESCRIPTION
## Summary

- make `Frame::get_header` match header names with `eq_ignore_ascii_case`
- update the method docs to match the new behavior
- add coverage for mixed-case lookups and first-match behavior with duplicate headers

Fixes #86.

## Checks

- `cargo fmt -- --check`
- `cargo test --test frame_unit get_header -- --nocapture`
- `cargo test --lib --verbose`
- `cargo test --tests`
- `cargo clippy --all-targets --all-features -- -D warnings`
