### PR TITLE
fix: close fast-RECEIPT race in receipt confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target
 # Contains mutation testing data
 **/mutants.out*/
 
+# macOS Finder metadata
+.DS_Store
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fast RECEIPT could be lost between `send_frame_with_receipt` and `wait_for_receipt` ([#82])
+  - `send_frame_with_receipt` registered a sender whose receiver it dropped immediately. A RECEIPT arriving before `wait_for_receipt` ran was delivered to that orphaned receiver and its registration removed, so the subsequent wait blocked for its full timeout and returned `ConnError::ReceiptTimeout` for a frame the broker had accepted. Most likely against a localhost or LAN broker.
+  - The confirmation receiver is now owned by the caller from the moment the frame is queued, so the response cannot arrive before there is somewhere to put it
+- `send_frame_with_receipt` no longer leaves a stale registration behind when the send itself fails
+
+### Changed
+
+- **Breaking**: `Connection::send_frame_with_receipt` returns `ReceiptHandle` instead of `String`. Await the confirmation with `handle.wait(timeout)` and read the generated id with `handle.receipt_id()`.
+- **Breaking**: `Connection::wait_for_receipt` is removed, superseded by `ReceiptHandle::wait`
+  - Before: `let id = conn.send_frame_with_receipt(f).await?; conn.wait_for_receipt(&id, t).await?;`
+  - After: `let h = conn.send_frame_with_receipt(f).await?; h.wait(t).await?;`
+  - Sending several frames before awaiting any still works — each handle is independent
+- `send_frame_confirmed` is now a thin wrapper over `send_frame_with_receipt` + `ReceiptHandle::wait`, rather than duplicating the registration and timeout logic
+
+### Documentation
+
+- README's receipt examples no longer set a `receipt` header by hand. Both `send_frame_with_receipt` and `send_frame_confirmed` add a generated one, and because `Frame::header` appends rather than overwrites, a hand-set id produced a frame with two `receipt` headers; brokers honour the first, so the confirmation never matched and the wait always timed out.
+
 ## [0.4.2] - 2026-06-24
 
 ### Added
@@ -203,3 +223,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#70]: https://github.com/iridiumdesign/iridium-stomp/pull/70
 [#72]: https://github.com/iridiumdesign/iridium-stomp/pull/72
 [#73]: https://github.com/iridiumdesign/iridium-stomp/pull/73
+[#82]: https://github.com/iridiumdesign/iridium-stomp/issues/82

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `send_frame_with_receipt` registered a sender whose receiver it dropped immediately. A RECEIPT arriving before `wait_for_receipt` ran was delivered to that orphaned receiver and its registration removed, so the subsequent wait blocked for its full timeout and returned `ConnError::ReceiptTimeout` for a frame the broker had accepted. Most likely against a localhost or LAN broker.
   - The confirmation receiver is now owned by the caller from the moment the frame is queued, so the response cannot arrive before there is somewhere to put it
 - `send_frame_with_receipt` no longer leaves a stale registration behind when the send itself fails
+- A caller-supplied `receipt` header silently broke `send_frame_with_receipt` and `send_frame_confirmed`
+  - `Frame::header` appends rather than overwrites, so a hand-set id put two `receipt` headers on the wire. Brokers honour the first, while the client tracked the generated id, so the confirmation never matched and the wait always timed out.
+  - Caller-supplied `receipt` headers are now replaced by the generated one, matched case-insensitively to agree with header lookup
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -215,19 +215,19 @@ use std::time::Duration;
 
 let msg = Frame::new("SEND")
     .header("destination", "/queue/important")
-    .receipt("msg-123")  // Request receipt with this ID
     .set_body(b"critical data".to_vec());
 
-// Send and wait for confirmation (with timeout)
+// Send and wait for confirmation (with timeout). The receipt header is added
+// for you - do not set one yourself.
 conn.send_frame_confirmed(msg, Duration::from_secs(5)).await?;
 
-// Or handle receipts manually
+// Or hold the confirmation and await it later. The receipt id is generated
+// for you and carried by the returned handle.
 let msg = Frame::new("SEND")
     .header("destination", "/queue/test")
-    .receipt("msg-456")
     .set_body(b"data".to_vec());
-conn.send_frame_with_receipt(msg).await?;
-conn.wait_for_receipt("msg-456", Duration::from_secs(5)).await?;
+let handle = conn.send_frame_with_receipt(msg).await?;
+handle.wait(Duration::from_secs(5)).await?;
 ```
 
 ### Connection Error Handling

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1513,6 +1513,16 @@ impl Connection {
             receipts.insert(receipt_id.clone(), tx);
         }
 
+        // Drop any caller-supplied receipt header before adding ours. `Frame::header`
+        // appends rather than overwrites, so leaving one in place would put two
+        // receipt headers on the wire; brokers honour the first, which would never
+        // match the id registered above. Matched case-insensitively, as header
+        // lookup is.
+        let mut frame = frame;
+        frame
+            .headers
+            .retain(|(key, _)| !key.eq_ignore_ascii_case("receipt"));
+
         // Add receipt header and send the frame
         let frame_with_receipt = frame.receipt(&receipt_id);
         if let Err(err) = self.send_frame(frame_with_receipt).await {
@@ -1978,10 +1988,15 @@ mod tests {
         String::from_utf8(bytes).unwrap()
     }
 
+    /// Read a header from a raw frame the way a broker does: the first
+    /// occurrence wins, and the name is matched case-insensitively.
     fn header_value<'a>(frame: &'a str, name: &str) -> &'a str {
         frame
             .lines()
-            .find_map(|line| line.strip_prefix(&format!("{}:", name)))
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                key.eq_ignore_ascii_case(name).then_some(value)
+            })
             .unwrap()
     }
 
@@ -2075,6 +2090,40 @@ mod tests {
             .wait(Duration::from_secs(2))
             .await
             .expect("RECEIPT delivered before the wait began must still resolve it");
+
+        conn.close().await;
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn caller_supplied_receipt_header_is_replaced_not_appended() {
+        // The stub echoes back the first receipt header it reads. If a
+        // caller-set header survived, the broker would answer with that id
+        // while the client tracked the generated one, and the wait would time
+        // out. Mixed case, since header lookup is case-insensitive.
+        let (addr, server) = start_receipt_success_server(Duration::ZERO);
+        let addr = addr.to_string();
+
+        let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+            .await
+            .unwrap();
+
+        let handle = conn
+            .send_frame_with_receipt(
+                Frame::new("SEND")
+                    .header("destination", "/queue/test")
+                    .header("Receipt", "caller-set")
+                    .set_body(b"payload".to_vec()),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(handle.receipt_id(), "caller-set");
+
+        handle
+            .wait(Duration::from_secs(2))
+            .await
+            .expect("generated receipt id must be the only one on the wire");
 
         conn.close().await;
         server.join().unwrap();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -643,6 +643,79 @@ pub struct Connection {
     pending_receipts: Arc<Mutex<PendingReceipts>>,
 }
 
+/// A pending receipt confirmation for a frame sent with
+/// [`Connection::send_frame_with_receipt`].
+///
+/// The handle owns the receiving half of the confirmation channel from the
+/// moment the frame is queued for sending. A RECEIPT that arrives before
+/// [`wait`](ReceiptHandle::wait) is called is therefore buffered in the channel
+/// rather than dropped, so the confirmation cannot be lost to a fast broker.
+///
+/// Handles are independent, so several frames may be sent before any of them is
+/// awaited:
+///
+/// ```ignore
+/// let mut handles = Vec::new();
+/// for order in orders {
+///     handles.push(conn.send_frame_with_receipt(order).await?);
+/// }
+/// for handle in handles {
+///     handle.wait(Duration::from_secs(5)).await?;
+/// }
+/// ```
+#[derive(Debug)]
+pub struct ReceiptHandle {
+    /// The client-generated receipt id carried by the sent frame.
+    receipt_id: String,
+    /// Resolves when the broker answers with RECEIPT or a matching ERROR.
+    rx: oneshot::Receiver<Result<(), ServerError>>,
+    /// Shared registry, used to deregister this receipt if the wait times out.
+    pending_receipts: Arc<Mutex<PendingReceipts>>,
+}
+
+impl ReceiptHandle {
+    /// The receipt id the client generated for this frame.
+    ///
+    /// This is the value sent in the frame's `receipt` header and echoed by the
+    /// broker in the `receipt-id` header of its response.
+    pub fn receipt_id(&self) -> &str {
+        &self.receipt_id
+    }
+
+    /// Wait for the broker to confirm the frame.
+    ///
+    /// # Parameters
+    /// - `timeout`: maximum time to wait for the broker's response.
+    ///
+    /// # Returns
+    /// `Ok(())` if the broker sent a RECEIPT, `Err(ConnError::FrameRejected)`
+    /// if it answered with an ERROR carrying this receipt id, or
+    /// `Err(ConnError::ReceiptTimeout)` if the timeout expired first.
+    pub async fn wait(self, timeout: Duration) -> Result<(), ConnError> {
+        let ReceiptHandle {
+            receipt_id,
+            rx,
+            pending_receipts,
+        } = self;
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(err))) => Err(ConnError::FrameRejected(err)),
+            Ok(Err(_)) => {
+                // Sender dropped without a response - connection likely gone.
+                Err(ConnError::Protocol(
+                    "receipt channel closed unexpectedly".into(),
+                ))
+            }
+            Err(_) => {
+                let mut receipts = pending_receipts.lock().await;
+                receipts.remove(&receipt_id);
+                Err(ConnError::ReceiptTimeout(receipt_id))
+            }
+        }
+    }
+}
+
 impl Connection {
     /// Heartbeat value that disables heartbeats entirely.
     ///
@@ -1399,30 +1472,42 @@ impl Connection {
         format!("rcpt-{}", RECEIPT_COUNTER.fetch_add(1, Ordering::SeqCst))
     }
 
-    /// Send a frame with a receipt request and return the receipt ID.
+    /// Send a frame with a receipt request and return a handle to its
+    /// confirmation.
     ///
-    /// This method adds a unique `receipt` header to the frame and registers
-    /// the receipt ID for tracking. Use `wait_for_receipt()` to wait for the
-    /// server's RECEIPT response.
+    /// This method adds a unique `receipt` header to the frame, registers the
+    /// receipt id for tracking, and returns a [`ReceiptHandle`]. Call
+    /// [`ReceiptHandle::wait`] to await the broker's RECEIPT response.
+    ///
+    /// Any `receipt` header already present on `frame` is ignored in favour of
+    /// the generated id; use [`ReceiptHandle::receipt_id`] to read it back.
+    ///
+    /// The returned handle owns the confirmation channel from the moment the
+    /// frame is queued, so the broker's response cannot arrive before there is
+    /// somewhere to put it. Awaiting may be deferred freely - see
+    /// [`ReceiptHandle`] for sending several frames before awaiting any.
     ///
     /// # Parameters
     /// - `frame`: the frame to send. A `receipt` header will be added.
     ///
     /// # Returns
-    /// The generated receipt ID that can be used with `wait_for_receipt()`.
+    /// A [`ReceiptHandle`] for the sent frame.
     ///
     /// # Example
     /// ```ignore
-    /// let receipt_id = conn.send_frame_with_receipt(frame).await?;
-    /// conn.wait_for_receipt(&receipt_id, Duration::from_secs(5)).await?;
+    /// let handle = conn.send_frame_with_receipt(frame).await?;
+    /// handle.wait(Duration::from_secs(5)).await?;
     /// ```
-    pub async fn send_frame_with_receipt(&self, frame: Frame) -> Result<String, ConnError> {
+    pub async fn send_frame_with_receipt(&self, frame: Frame) -> Result<ReceiptHandle, ConnError> {
         let receipt_id = Self::generate_receipt_id();
 
-        // Create the oneshot channel for notification
-        let (tx, _rx) = oneshot::channel();
+        // Create the oneshot channel for notification. The receiver goes into
+        // the returned handle, so it stays alive for as long as the caller
+        // cares about the response.
+        let (tx, rx) = oneshot::channel();
 
-        // Register the pending receipt
+        // Register the pending receipt before sending, so the background task
+        // can never see the response with nothing registered for it.
         {
             let mut receipts = self.pending_receipts.lock().await;
             receipts.insert(receipt_id.clone(), tx);
@@ -1430,72 +1515,31 @@ impl Connection {
 
         // Add receipt header and send the frame
         let frame_with_receipt = frame.receipt(&receipt_id);
-        self.send_frame(frame_with_receipt).await?;
-
-        Ok(receipt_id)
-    }
-
-    /// Wait for a receipt confirmation from the server.
-    ///
-    /// This method blocks until the server sends a RECEIPT or ERROR frame with
-    /// the matching receipt-id, or until the timeout expires.
-    ///
-    /// # Parameters
-    /// - `receipt_id`: the receipt ID returned by `send_frame_with_receipt()`.
-    /// - `timeout`: maximum time to wait for the receipt.
-    ///
-    /// # Returns
-    /// `Ok(())` if the receipt was received, `Err(ConnError::FrameRejected)`
-    /// if the broker rejected the frame, or `Err(ConnError::ReceiptTimeout)` if
-    /// the timeout expired.
-    ///
-    /// # Example
-    /// ```ignore
-    /// let receipt_id = conn.send_frame_with_receipt(frame).await?;
-    /// conn.wait_for_receipt(&receipt_id, Duration::from_secs(5)).await?;
-    /// println!("Message confirmed!");
-    /// ```
-    pub async fn wait_for_receipt(
-        &self,
-        receipt_id: &str,
-        timeout: Duration,
-    ) -> Result<(), ConnError> {
-        // Get the receiver for this receipt
-        let rx = {
+        if let Err(err) = self.send_frame(frame_with_receipt).await {
+            // The frame never went out; deregister rather than leave an entry
+            // that nothing will ever answer.
             let mut receipts = self.pending_receipts.lock().await;
-            // Re-create the oneshot channel and swap out the sender
-            let (tx, rx) = oneshot::channel();
-            if let Some(old_tx) = receipts.insert(receipt_id.to_string(), tx) {
-                // Drop the old sender - this is expected if called after send_frame_with_receipt
-                drop(old_tx);
-            }
-            rx
-        };
-
-        // Wait for the receipt with timeout
-        match tokio::time::timeout(timeout, rx).await {
-            Ok(Ok(Ok(()))) => Ok(()),
-            Ok(Ok(Err(err))) => Err(ConnError::FrameRejected(err)),
-            Ok(Err(_)) => {
-                // Channel was closed without receiving - connection likely dropped
-                Err(ConnError::Protocol(
-                    "receipt channel closed unexpectedly".into(),
-                ))
-            }
-            Err(_) => {
-                // Timeout expired - clean up the pending receipt
-                let mut receipts = self.pending_receipts.lock().await;
-                receipts.remove(receipt_id);
-                Err(ConnError::ReceiptTimeout(receipt_id.to_string()))
-            }
+            receipts.remove(&receipt_id);
+            return Err(err);
         }
+
+        Ok(ReceiptHandle {
+            receipt_id,
+            rx,
+            pending_receipts: self.pending_receipts.clone(),
+        })
     }
 
     /// Send a frame and wait for server confirmation via RECEIPT.
     ///
-    /// This is a convenience method that combines `send_frame_with_receipt()`
-    /// and `wait_for_receipt()`. Use this when you want to ensure a frame
-    /// was processed by the server before continuing.
+    /// This is a convenience method that combines
+    /// [`send_frame_with_receipt`](Connection::send_frame_with_receipt) and
+    /// [`ReceiptHandle::wait`]. Use this when you want to ensure a frame was
+    /// processed by the server before continuing.
+    ///
+    /// Any `receipt` header already present on `frame` is ignored in favour of
+    /// a generated id. Reach for `send_frame_with_receipt` directly when you
+    /// need to send several frames before awaiting any of them.
     ///
     /// # Parameters
     /// - `frame`: the frame to send.
@@ -1519,35 +1563,10 @@ impl Connection {
         frame: Frame,
         timeout: Duration,
     ) -> Result<(), ConnError> {
-        let receipt_id = Self::generate_receipt_id();
-
-        // Create the oneshot channel for notification
-        let (tx, rx) = oneshot::channel();
-
-        // Register the pending receipt before sending
-        {
-            let mut receipts = self.pending_receipts.lock().await;
-            receipts.insert(receipt_id.clone(), tx);
-        }
-
-        // Add receipt header and send the frame
-        let frame_with_receipt = frame.receipt(&receipt_id);
-        self.send_frame(frame_with_receipt).await?;
-
-        // Wait for the receipt with timeout
-        match tokio::time::timeout(timeout, rx).await {
-            Ok(Ok(Ok(()))) => Ok(()),
-            Ok(Ok(Err(err))) => Err(ConnError::FrameRejected(err)),
-            Ok(Err(_)) => Err(ConnError::Protocol(
-                "receipt channel closed unexpectedly".into(),
-            )),
-            Err(_) => {
-                // Timeout expired - clean up
-                let mut receipts = self.pending_receipts.lock().await;
-                receipts.remove(&receipt_id);
-                Err(ConnError::ReceiptTimeout(receipt_id))
-            }
-        }
+        self.send_frame_with_receipt(frame)
+            .await?
+            .wait(timeout)
+            .await
     }
 
     /// Subscribe to a destination.
@@ -1999,6 +2018,68 @@ mod tests {
         (addr, handle)
     }
 
+    fn start_receipt_success_server(
+        response_delay: Duration,
+    ) -> (SocketAddr, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let handle = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _connect = read_stomp_frame(&mut stream);
+                stream
+                    .write_all(b"CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0")
+                    .unwrap();
+                stream.flush().unwrap();
+
+                let send_frame = read_stomp_frame(&mut stream);
+                let receipt_id = header_value(&send_frame, "receipt").to_string();
+                thread::sleep(response_delay);
+                let receipt_frame = format!("RECEIPT\nreceipt-id:{}\n\n\0", receipt_id);
+                stream.write_all(receipt_frame.as_bytes()).unwrap();
+                stream.flush().unwrap();
+
+                thread::sleep(Duration::from_millis(100));
+            }
+        });
+
+        (addr, handle)
+    }
+
+    #[tokio::test]
+    async fn receipt_arriving_before_the_wait_is_not_lost() {
+        // The broker answers with no delay, so the RECEIPT lands while the
+        // caller is still holding the handle. Before #82 the background task
+        // fired an orphaned sender and removed the registration, so the wait
+        // below timed out on a frame the broker had already confirmed.
+        let (addr, server) = start_receipt_success_server(Duration::ZERO);
+        let addr = addr.to_string();
+
+        let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+            .await
+            .unwrap();
+
+        let handle = conn
+            .send_frame_with_receipt(
+                Frame::new("SEND")
+                    .header("destination", "/queue/fast")
+                    .set_body(b"payload".to_vec()),
+            )
+            .await
+            .unwrap();
+
+        // Let the response arrive and be dispatched before anyone awaits it.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        handle
+            .wait(Duration::from_secs(2))
+            .await
+            .expect("RECEIPT delivered before the wait began must still resolve it");
+
+        conn.close().await;
+        server.join().unwrap();
+    }
+
     #[tokio::test]
     async fn error_with_receipt_id_rejects_confirmed_send_and_stays_inbound() {
         let (addr, server) =
@@ -2057,7 +2138,7 @@ mod tests {
             .await
             .unwrap();
 
-        let receipt_id = conn
+        let handle = conn
             .send_frame_with_receipt(
                 Frame::new("SEND")
                     .header("destination", "/queue/forbidden")
@@ -2066,9 +2147,8 @@ mod tests {
             .await
             .unwrap();
 
-        let result = conn
-            .wait_for_receipt(&receipt_id, Duration::from_secs(2))
-            .await;
+        let receipt_id = handle.receipt_id().to_string();
+        let result = handle.wait(Duration::from_secs(2)).await;
 
         match result {
             Err(ConnError::FrameRejected(err)) => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1145,7 +1145,7 @@ impl Connection {
                                         let mut need_pending = false;
                                         if let Some(sub_id) = &sub_opt {
                                             let map = subscriptions.lock().await;
-                                            for (_dest, vec) in map.iter() {
+                                            for vec in map.values() {
                                                 for entry in vec.iter() {
                                                     if &entry.id == sub_id && entry.ack != "auto" {
                                                         need_pending = true;
@@ -1197,7 +1197,7 @@ impl Connection {
                                         // Deliver to subscribers.
                                         if let Some(sub_id) = sub_opt {
                                             let mut map = subscriptions.lock().await;
-                                            for (_dest, vec) in map.iter_mut() {
+                                            for vec in map.values_mut() {
                                                 vec.retain(|entry| {
                                                     if entry.id == sub_id {
                                                         let _ = entry.sender.try_send(f.clone());
@@ -1729,7 +1729,7 @@ impl Connection {
                     let mut ack_mode = "client".to_string();
                     {
                         let map = self.subscriptions.lock().await;
-                        'outer: for (_dest, vec) in map.iter() {
+                        'outer: for vec in map.values() {
                             for entry in vec.iter() {
                                 if entry.id == subscription_id {
                                     ack_mode = entry.ack.clone();
@@ -1795,7 +1795,7 @@ impl Connection {
                     let mut ack_mode = "client".to_string();
                     {
                         let map = self.subscriptions.lock().await;
-                        'outer2: for (_dest, vec) in map.iter() {
+                        'outer2: for vec in map.values() {
                             for entry in vec.iter() {
                                 if entry.id == subscription_id {
                                     ack_mode = entry.ack.clone();

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -54,8 +54,12 @@ impl Frame {
     /// Request a receipt for this frame (builder style).
     ///
     /// When sent, the server will respond with a RECEIPT frame containing
-    /// the same receipt ID. Use this with `Connection::wait_for_receipt()`
-    /// to confirm delivery.
+    /// the same receipt ID.
+    ///
+    /// Use this only with `Connection::send_frame`, which sends the frame
+    /// as-is. `Connection::send_frame_with_receipt` and
+    /// `Connection::send_frame_confirmed` add a generated receipt header of
+    /// their own and track it for you.
     ///
     /// Parameters
     /// - `id`: the receipt identifier. Must be unique per connection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,11 @@ pub mod subscription;
 pub use codec::{StompCodec, StompItem};
 
 /// Re-export the high-level `Connection`, `AckMode`, `ConnectOptions`, `ConnError`,
-/// `Heartbeat`, `ReceivedFrame`, `ServerError`, and the heartbeat helper functions.
+/// `Heartbeat`, `ReceiptHandle`, `ReceivedFrame`, `ServerError`, and the heartbeat
+/// helper functions.
 pub use connection::{
-    AckMode, ConnError, ConnectOptions, Connection, Heartbeat, ReceivedFrame, ServerError,
-    negotiate_heartbeats, parse_heartbeat_header,
+    AckMode, ConnError, ConnectOptions, Connection, Heartbeat, ReceiptHandle, ReceivedFrame,
+    ServerError, negotiate_heartbeats, parse_heartbeat_header,
 };
 
 /// Re-export the `Frame` type used to construct/send and receive frames.

--- a/tests/minimized_regression.rs
+++ b/tests/minimized_regression.rs
@@ -30,7 +30,7 @@ fn minimized_replay_should_decode_all_frames() {
     for c in chunks {
         buf.extend_from_slice(c);
         loop {
-            eprintln!("calling decode: buf len={} -> {:02x?}", buf.len(), &buf);
+            eprintln!("calling decode: buf len={} -> {:02x?}", buf.len(), buf);
             match dec.decode(&mut buf) {
                 Ok(Some(StompItem::Frame(f))) => {
                     eprintln!("decoded frame, remaining buf len={}", buf.len());
@@ -60,7 +60,7 @@ fn minimized_replay_should_decode_all_frames() {
     }
 
     if decoded != expected {
-        eprintln!("combined (len={}): {:02x?}", combined.len(), &combined);
+        eprintln!("combined (len={}): {:02x?}", combined.len(), combined);
         let nul_positions: Vec<usize> = combined
             .iter()
             .enumerate()
@@ -78,7 +78,7 @@ fn minimized_replay_should_decode_all_frames() {
         eprintln!(
             "remaining buf after drain (len={}): {:02x?}",
             buf.len(),
-            &buf
+            buf
         );
     }
     assert_eq!(

--- a/tests/regression_replay.rs
+++ b/tests/regression_replay.rs
@@ -48,7 +48,7 @@ fn replay_problematic_chunk_sequence() {
 
     for c in chunks {
         buf.extend_from_slice(c);
-        eprintln!("after extend: buf len={} -> {:02x?}", buf.len(), &buf);
+        eprintln!("after extend: buf len={} -> {:02x?}", buf.len(), buf);
         loop {
             eprintln!("attempting decode: buf len={}", buf.len());
             match dec.decode(&mut buf) {
@@ -74,7 +74,7 @@ fn replay_problematic_chunk_sequence() {
     }
 
     if decoded != expected {
-        eprintln!("combined (len={}): {:02x?}", combined.len(), &combined);
+        eprintln!("combined (len={}): {:02x?}", combined.len(), combined);
         let nul_positions: Vec<usize> = combined
             .iter()
             .enumerate()
@@ -92,7 +92,7 @@ fn replay_problematic_chunk_sequence() {
         eprintln!(
             "remaining buf after drain (len={}): {:02x?}",
             buf.len(),
-            &buf
+            buf
         );
         panic!(
             "decoded frames mismatch (decoded={}, expected={})",


### PR DESCRIPTION
send_frame_with_receipt registered a oneshot sender in pending_receipts but dropped its receiver immediately, and wait_for_receipt created a second, unrelated pair. When the broker's RECEIPT landed between the two calls the background task fired the orphaned sender and removed the registration, so the swap-in by wait_for_receipt registered a channel nothing would ever fire. The wait then blocked for its full timeout and returned ReceiptTimeout for a frame the broker had accepted. Most likely against a localhost or LAN broker, where the response can beat the caller to the wait.

send_frame_with_receipt now returns a ReceiptHandle owning the receiver from the moment the frame is queued, so an early response lands in a live channel instead of being dropped. Ordering stops mattering rather than being narrowed. wait_for_receipt is removed in favour of ReceiptHandle::wait; handles are independent, so sending several frames before awaiting any of them still works.

  before: let id = conn.send_frame_with_receipt(f).await?;
          conn.wait_for_receipt(&id, t).await?;
  after:  let h = conn.send_frame_with_receipt(f).await?;
          h.wait(t).await?;

Also in this change:

  send_frame_confirmed becomes a thin wrapper over the new pair. It had
  its own copy of the registration and timeout logic, which is how the
  two paths drifted apart to begin with.

  send_frame_with_receipt deregisters when the send itself fails, rather
  than leaving an entry nothing will ever answer.

  Both README receipt examples set a receipt header by hand, which never
  worked: Frame::header appends rather than overwrites, so the frame went
  out with two receipt headers. Brokers honour the first, while the
  registration is keyed on the generated id, so the confirmation never
  matched and the wait always timed out. The examples now let the library
  generate the id, and Frame::receipt documents that it belongs with
  send_frame only.

The regression test drives a broker stub that answers with no delay and sleeps before awaiting, so the RECEIPT is always dispatched first. It fails against the previous receiver handling.

BREAKING CHANGE: Connection::send_frame_with_receipt returns ReceiptHandle instead of String, and Connection::wait_for_receipt is removed. Use ReceiptHandle::wait and ReceiptHandle::receipt_id.

Closes #82