### PR TITLE
fix: make close terminate the background task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Connection::close` did not terminate the background task; it reconnected indefinitely ([#96])
+  - Every closed connection left a task re-establishing a broker session every 30s for the life of the process, so a long-running service accumulated them. From the broker's side this looked like sessions and reconnects with no client that owned them.
+  - Two independent causes. The task subscribed to the shutdown broadcast from inside its own loop, so a `close` issued before the task was first polled reached a channel with no subscribers and was discarded outright, and a shutdown arriving during the reconnect backoff was dropped by the next iteration's re-subscribe. Separately, the inner select consumed the shutdown message while the reconnect check re-read the same drained receiver and concluded it should reconnect — reachable whenever a `Connection` clone kept the outbound channel open, as the CLI does.
+  - The task now subscribes once, before it is spawned, and keeps that receiver for its lifetime; the reconnect check consults a flag set where the signal is consumed rather than re-reading it
+
 - Fast RECEIPT could be lost between `send_frame_with_receipt` and `wait_for_receipt` ([#82])
   - `send_frame_with_receipt` registered a sender whose receiver it dropped immediately. A RECEIPT arriving before `wait_for_receipt` ran was delivered to that orphaned receiver and its registration removed, so the subsequent wait blocked for its full timeout and returned `ConnError::ReceiptTimeout` for a frame the broker had accepted. Most likely against a localhost or LAN broker.
   - The confirmation receiver is now owned by the caller from the moment the frame is queued, so the response cannot arrive before there is somewhere to put it
@@ -227,3 +232,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#72]: https://github.com/iridiumdesign/iridium-stomp/pull/72
 [#73]: https://github.com/iridiumdesign/iridium-stomp/pull/73
 [#82]: https://github.com/iridiumdesign/iridium-stomp/issues/82
+[#96]: https://github.com/iridiumdesign/iridium-stomp/issues/96

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -936,8 +936,15 @@ impl Connection {
             }
         };
 
-        // Now spawn background task for ongoing I/O and reconnection
-        let shutdown_tx_clone = shutdown_tx.clone();
+        // Now spawn background task for ongoing I/O and reconnection.
+        //
+        // Subscribe before spawning, and keep the one receiver for the task's
+        // whole life. A broadcast drops a message when nobody is subscribed and
+        // delivers only to receivers that existed when it was sent, so
+        // subscribing inside the task would lose a shutdown signalled before the
+        // task is first polled, and re-subscribing per iteration would discard
+        // one that arrived during the reconnect backoff.
+        let mut shutdown_sub = shutdown_tx.subscribe();
         let subscriptions_clone = subscriptions.clone();
 
         tokio::spawn(async move {
@@ -959,8 +966,6 @@ impl Connection {
             const SUBSCRIPTION_ERROR_THRESHOLD: u32 = 3;
 
             loop {
-                let mut shutdown_sub = shutdown_tx_clone.subscribe();
-
                 // Check for shutdown before attempting connection
                 tokio::select! {
                     biased;
@@ -1105,9 +1110,14 @@ impl Connection {
 
                 let conn_start = tokio::time::Instant::now();
 
+                // Set when the branch below takes the shutdown signal. The
+                // reconnect check after this loop cannot re-read it from
+                // `shutdown_sub`, which is drained by then.
+                let mut shutting_down = false;
+
                 'conn: loop {
                     tokio::select! {
-                        _ = shutdown_sub.recv() => { let _ = sink.close().await; break 'conn; }
+                        _ = shutdown_sub.recv() => { let _ = sink.close().await; shutting_down = true; break 'conn; }
                         maybe = out_rx.recv() => {
                             match maybe {
                                 Some(item) => if sink.send(item).await.is_err() { break 'conn } else { writer_last_sent.store(current_millis(), Ordering::SeqCst); }
@@ -1319,7 +1329,7 @@ impl Connection {
                     }
                 }
 
-                if shutdown_sub.try_recv().is_ok() {
+                if shutting_down || shutdown_sub.try_recv().is_ok() {
                     break;
                 }
                 let stable_duration = conn_start.elapsed();

--- a/tests/close_terminates_task.rs
+++ b/tests/close_terminates_task.rs
@@ -1,0 +1,136 @@
+//! Regression coverage for #96: `Connection::close` must terminate the
+//! background task rather than leaving it reconnecting on a backoff loop.
+//!
+//! The stubs here deliberately keep accepting connections after the client
+//! closes. The stubs used elsewhere accept exactly one, which is why a
+//! reconnect after close went unnoticed - it failed against a closed listener
+//! and the test process exited before anyone looked.
+
+use iridium_stomp::Connection;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+
+/// A broker that stays up and counts every connection it accepts, answering
+/// CONNECT with CONNECTED and then holding the socket open.
+fn start_counting_broker() -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    let accepts = Arc::new(AtomicUsize::new(0));
+    let accepts_clone = accepts.clone();
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            accepts_clone.fetch_add(1, Ordering::SeqCst);
+            thread::spawn(move || {
+                let mut buf = [0u8; 4096];
+                if stream.read(&mut buf).is_ok() {
+                    let _ = stream.write_all(b"CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0");
+                    let _ = stream.flush();
+                }
+                thread::sleep(Duration::from_secs(30));
+            });
+        }
+    });
+
+    (addr, accepts)
+}
+
+/// Backoff starts at 1s and doubles to 2s for a short-lived connection, so a
+/// stray reconnect lands ~2s after close. Wait well past that.
+const OBSERVE: Duration = Duration::from_secs(6);
+
+/// The task consumed the shutdown broadcast in its inner select, and the
+/// reconnect check then re-read the drained receiver and saw nothing.
+#[tokio::test]
+async fn close_terminates_the_background_task() {
+    let (addr, accepts) = start_counting_broker();
+
+    let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+        .await
+        .unwrap();
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "the initial connect should be the broker's only session"
+    );
+
+    // Give the task a chance to be polled, so it is parked in its select with
+    // the shutdown receiver live. This is the ordinary case.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    conn.close().await;
+    tokio::time::sleep(OBSERVE).await;
+
+    let total = accepts.load(Ordering::SeqCst);
+    assert_eq!(
+        total, 1,
+        "close() must end the background task, but the broker saw {} sessions",
+        total
+    );
+}
+
+/// The connect handshake happens before the task is spawned, so a close with no
+/// await points in between reaches a broadcast with no subscribers. The signal
+/// was dropped outright and the task reconnected forever.
+#[tokio::test]
+async fn close_immediately_after_connect_terminates_the_background_task() {
+    let (addr, accepts) = start_counting_broker();
+
+    let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+        .await
+        .unwrap();
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "the initial connect should be the broker's only session"
+    );
+
+    // No await between connect returning and close: the task may not have been
+    // polled even once yet.
+    conn.close().await;
+    tokio::time::sleep(OBSERVE).await;
+
+    let total = accepts.load(Ordering::SeqCst);
+    assert_eq!(
+        total, 1,
+        "close() must end the background task even when it has not been polled yet, \
+         but the broker saw {} sessions",
+        total
+    );
+}
+
+/// `Connection` is `Clone`, and the CLI keeps clones alive for its subscriber
+/// and error-monitor tasks. With a clone outstanding, `out_tx` is not dropped by
+/// `close`, so the outbound branch of the task's select is never ready and the
+/// shutdown branch wins on its own - draining the broadcast before the
+/// reconnect check reads it.
+#[tokio::test]
+async fn close_terminates_the_background_task_with_a_clone_outstanding() {
+    let (addr, accepts) = start_counting_broker();
+
+    let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+        .await
+        .unwrap();
+    assert_eq!(accepts.load(Ordering::SeqCst), 1);
+
+    // Held for the rest of the test, as the CLI holds its clones.
+    let _clone = conn.clone();
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    conn.close().await;
+    tokio::time::sleep(OBSERVE).await;
+
+    let total = accepts.load(Ordering::SeqCst);
+    assert_eq!(
+        total, 1,
+        "close() must end the background task while a clone is alive, \
+         but the broker saw {} sessions",
+        total
+    );
+}


### PR DESCRIPTION
close() signalled shutdown on a broadcast channel but the task survived it and reconnected on a backoff loop, indefinitely. Every closed connection left a task re-establishing a broker session every 30s for the life of the process. From the broker's side that looks like sessions and reconnects with no client that admits to owning them.

Two independent causes, each sufficient on its own.

The task subscribed from inside its own loop. A broadcast discards a message when nobody is subscribed and delivers only to receivers that existed when it was sent, so a close issued before the task was first polled - the connect handshake completes before the spawn, so no await between connect and close is needed for this - reached a channel with no subscribers and was dropped outright. The per-iteration re-subscribe had the same shape: a shutdown arriving during the backoff sleep was discarded by the next iteration's fresh receiver.

Separately, the inner select consumed the message via shutdown_sub.recv(), then the reconnect check re-read the same drained receiver with try_recv() and concluded it should reconnect. This needs the shutdown branch to win its select alone, which happens whenever a Connection clone holds the outbound channel open so the out_rx-closed branch is not also ready. The CLI keeps clones for its subscriber and error-monitor tasks, so its quit path hits exactly this.

The task now subscribes once, before it is spawned, and keeps that receiver for its lifetime. The reconnect check consults a flag set where the signal is consumed rather than trying to read it twice.

The regression tests use a broker stub that keeps accepting connections and counts sessions. The stubs elsewhere accept exactly one, which is why this went unseen: the reconnect failed against a closed listener and the test process exited before it mattered. One test per cause, plus the clone case; each fails with its corresponding fix reverted.

Closes #96