### PR TITLE
refactor!: remove SubscriptionOptions::durable_queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking**: `SubscriptionOptions::durable_queue` is removed ([#91])
+  - Despite the name it did not request durability. Its only effect was to override the `destination` argument, so a user who set it expecting an ActiveMQ durable subscription silently got a plain one against a different destination — and because STOMP cannot reject a "wrong" subscription header, the broker accepted it without complaint and messages quietly failed to persist across a disconnect.
+  - Durability is requested through `SubscriptionOptions::headers`, which is what the struct-level docs already described. Pass the broker's own header (ActiveMQ's `activemq.subscriptionName`, for example). Where the durable queue is declared administratively, as on RabbitMQ, name it as the `destination` and no options are needed.
+  - Migration: move the value into the `destination` argument. `subscribe_with_options("/exchange/x", ack, opts)` with `durable_queue: Some("/queue/y")` was only ever subscribing to `/queue/y`, so it becomes `subscribe_with_options("/queue/y", ack, opts)`.
 - **Breaking**: `Connection::send_frame_with_receipt` returns `ReceiptHandle` instead of `String`. Await the confirmation with `handle.wait(timeout)` and read the generated id with `handle.receipt_id()`.
 - **Breaking**: `Connection::wait_for_receipt` is removed, superseded by `ReceiptHandle::wait`
   - Before: `let id = conn.send_frame_with_receipt(f).await?; conn.wait_for_receipt(&id, t).await?;`
@@ -33,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- `docs/durable_subscriptions.md` no longer presents `durable_queue` as the RabbitMQ durability mechanism ([#91]). Durability there is a property of the administratively declared queue, so the guide now simply subscribes to it by name. `docs/subscriptions.md` gains a note that STOMP has no durable-subscription concept of its own and that durability is whatever the broker defines it to be.
+- `examples/subscribe.rs` passed `/exchange/topic` as the destination while setting `durable_queue` to `/queue/example-durable`, so it silently subscribed to the latter and demonstrated the confusion the field caused ([#91]). It now names the queue it means.
 - README's receipt examples no longer set a `receipt` header by hand. Both `send_frame_with_receipt` and `send_frame_confirmed` add a generated one, and because `Frame::header` appends rather than overwrites, a hand-set id produced a frame with two `receipt` headers; brokers honour the first, so the confirmation never matched and the wait always timed out.
 
 ## [0.4.2] - 2026-06-24
@@ -232,4 +238,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#72]: https://github.com/iridiumdesign/iridium-stomp/pull/72
 [#73]: https://github.com/iridiumdesign/iridium-stomp/pull/73
 [#82]: https://github.com/iridiumdesign/iridium-stomp/issues/82
+[#91]: https://github.com/iridiumdesign/iridium-stomp/issues/91
 [#96]: https://github.com/iridiumdesign/iridium-stomp/issues/96

--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ let options = SubscriptionOptions {
         ("activemq.subscriptionName".into(), "my-durable-sub".into()),
         ("selector".into(), "priority > 5".into()),
     ],
-    durable_queue: None,
 };
 
 let sub = conn.subscribe_with_options("/topic/events", AckMode::Client, options).await?;

--- a/docs/durable_subscriptions.md
+++ b/docs/durable_subscriptions.md
@@ -43,11 +43,13 @@ equivalent pattern is a durable named queue bound to an exchange.
 
 ### Client code
 
-Use `SubscriptionOptions.durable_queue` to subscribe to the named queue:
+Durability here is a property of the queue you declared above, not of the
+SUBSCRIBE frame. Subscribe to that queue by naming it as the destination —
+no options are needed at all:
 
 ```rust
-use iridium_stomp::{Connection, SubscriptionOptions};
 use iridium_stomp::AckMode;
+use iridium_stomp::Connection;
 
 let conn = Connection::connect(
     "127.0.0.1:61613",
@@ -56,13 +58,8 @@ let conn = Connection::connect(
     Connection::DEFAULT_HEARTBEAT,
 ).await?;
 
-let opts = SubscriptionOptions {
-    durable_queue: Some("/queue/my-app-queue".to_string()),
-    headers: vec![],
-};
-
 let sub = conn
-    .subscribe_with_options("/exchange/amq.topic", AckMode::Client, opts)
+    .subscribe("/queue/my-app-queue", AckMode::Client)
     .await?;
 ```
 
@@ -101,7 +98,6 @@ let conn = Connection::connect_with_options(
 ).await?;
 
 let opts = SubscriptionOptions {
-    durable_queue: None,
     headers: vec![
         ("activemq.subscriptionName".to_string(), "my-durable-sub".to_string()),
     ],

--- a/docs/subscriber-guide.md
+++ b/docs/subscriber-guide.md
@@ -239,7 +239,6 @@ let sub_opts = SubscriptionOptions {
     headers: vec![
         ("activemq.subscriptionName".into(), "my-durable-sub".into()),
     ],
-    durable_queue: None,
 };
 
 // Subscribe to multiple durable topics
@@ -254,8 +253,7 @@ for (dest, sub_name) in &topics {
         headers: vec![
             ("activemq.subscriptionName".into(), (*sub_name).into()),
         ],
-        durable_queue: None,
-    };
+        };
     subs.push(conn.subscribe_with_options(dest, AckMode::ClientIndividual, sub_opts).await?);
 }
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -26,18 +26,20 @@ let sub = conn.subscribe("/queue/orders", AckMode::Auto).await?;
 ### `subscribe_with_options(destination, ack, options)`
 
 Accepts a `SubscriptionOptions` struct for typed configuration. Use this
-when you need a durable queue name or broker-specific headers.
+when you need broker-specific headers, such as a durable subscription name.
 
 ```rust
 use iridium_stomp::{AckMode, SubscriptionOptions};
 
 let opts = SubscriptionOptions {
-    durable_queue: Some("/queue/my-durable-queue".to_string()),
-    headers: vec![],
+    headers: vec![(
+        "activemq.subscriptionName".to_string(),
+        "my-durable-sub".to_string(),
+    )],
 };
 
 let sub = conn
-    .subscribe_with_options("/exchange/amq.topic", AckMode::Client, opts)
+    .subscribe_with_options("/topic/my-topic", AckMode::Client, opts)
     .await?;
 ```
 
@@ -64,10 +66,15 @@ let sub = conn
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `durable_queue` | `Option<String>` | Override the destination with a named queue (useful for RabbitMQ durable queues). |
 | `headers` | `Vec<(String, String)>` | Extra headers included on the SUBSCRIBE frame (e.g., broker-specific durable subscription names). |
 
-Both fields are preserved internally and replayed on reconnect.
+Headers are preserved internally and replayed on reconnect.
+
+STOMP has no durable-subscription concept of its own, so durability is
+whatever the broker defines it to be. On ActiveMQ that is a header such as
+`activemq.subscriptionName`; on RabbitMQ the queue is declared
+administratively and you simply subscribe to it by name as the
+`destination`.
 
 ---
 
@@ -94,8 +101,6 @@ or options you provided are all preserved and replayed.
 
 This means:
 
-- Durable queue names (`durable_queue`) are sent again, so the broker
-  resumes delivery from the same queue.
 - Broker-specific headers (e.g., `activemq.subscriptionName`) are resent,
   so durable topic subscriptions are restored.
 - Your application code does not need to handle resubscription — the

--- a/examples/subscribe.rs
+++ b/examples/subscribe.rs
@@ -16,16 +16,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     // Subscribe to a queue using client ack mode (so we must ack messages).
-    // Here we use `SubscriptionOptions` to optionally specify a durable
-    // queue name (for brokers like RabbitMQ) or include broker-specific
-    // headers (for example ActiveMQ's durable subscription headers).
-    let opts = SubscriptionOptions {
-        durable_queue: Some("/queue/example-durable".to_string()),
-        headers: vec![],
-    };
+    // `SubscriptionOptions` carries broker-specific headers; durability is
+    // requested through them, for example ActiveMQ's durable subscription
+    // headers. On brokers where the durable queue is declared
+    // administratively, such as RabbitMQ, name it as the destination and no
+    // extra headers are needed.
+    let opts = SubscriptionOptions { headers: vec![] };
 
     let mut sub = conn
-        .subscribe_with_options("/exchange/topic", AckMode::Client, opts)
+        .subscribe_with_options("/queue/example-durable", AckMode::Client, opts)
         .await?;
 
     println!("subscribed id={} dest={}", sub.id(), sub.destination());

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1661,20 +1661,16 @@ impl Connection {
     /// Subscribe with a typed `SubscriptionOptions` structure.
     ///
     /// `SubscriptionOptions.headers` are forwarded to the broker and persisted
-    /// for automatic resubscribe after reconnect. If `durable_queue` is set,
-    /// it will be used as the actual destination instead of `destination`.
+    /// for automatic resubscribe after reconnect. Durable subscriptions are
+    /// requested through those headers - see the module docs for
+    /// [`SubscriptionOptions`](crate::subscription::SubscriptionOptions).
     pub async fn subscribe_with_options(
         &self,
         destination: &str,
         ack: AckMode,
         options: crate::subscription::SubscriptionOptions,
     ) -> Result<crate::subscription::Subscription, ConnError> {
-        let dest = options
-            .durable_queue
-            .as_deref()
-            .unwrap_or(destination)
-            .to_string();
-        self.subscribe_with_headers(&dest, ack, options.headers)
+        self.subscribe_with_headers(destination, ack, options.headers)
             .await
     }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -11,14 +11,29 @@ use tokio::sync::mpsc;
 /// they can be re-sent on reconnect. This allows broker-specific durable
 /// subscription extensions to be used (for example ActiveMQ's durable
 /// subscription headers) while keeping the library generic.
+///
+/// # Durability
+///
+/// Durability is requested through `headers`, using whatever header the broker
+/// defines for it - STOMP itself has no durable-subscription concept. For
+/// example, ActiveMQ uses `activemq.subscriptionName`:
+///
+/// ```ignore
+/// let options = SubscriptionOptions {
+///     headers: vec![(
+///         "activemq.subscriptionName".to_string(),
+///         "my-durable-sub".to_string(),
+///     )],
+/// };
+/// ```
+///
+/// On brokers where a durable queue is declared administratively, such as
+/// RabbitMQ, pass that queue as the `destination` argument; nothing extra is
+/// needed here.
 #[derive(Debug, Clone, Default)]
 pub struct SubscriptionOptions {
     /// Extra headers to include on the SUBSCRIBE frame.
     pub headers: Vec<(String, String)>,
-
-    /// Optional named queue to subscribe to (convenience; typically you can
-    /// just put this in the `destination` argument). Kept for clarity.
-    pub durable_queue: Option<String>,
 }
 
 /// A lightweight handle returned from `Connection::subscribe` that packages the

--- a/tests/subscribe_api_integration.rs
+++ b/tests/subscribe_api_integration.rs
@@ -65,23 +65,6 @@ fn test_stream_api_usage_pattern() {
 // Acceptance Criteria 2: Support durable subscriptions
 // =============================================================================
 
-/// Test that SubscriptionOptions supports durable queue configuration.
-/// This demonstrates support for RabbitMQ-style durable queues.
-#[test]
-fn test_subscription_options_durable_queue() {
-    // RabbitMQ durable subscription pattern
-    let opts = SubscriptionOptions {
-        durable_queue: Some("/queue/durable-events".to_string()),
-        headers: vec![],
-    };
-
-    assert_eq!(
-        opts.durable_queue,
-        Some("/queue/durable-events".to_string()),
-        "Should support durable queue configuration"
-    );
-}
-
 /// Test that SubscriptionOptions supports broker-specific headers.
 /// This demonstrates support for ActiveMQ-style durable subscriptions
 /// and other broker-specific features via custom headers.
@@ -89,7 +72,6 @@ fn test_subscription_options_durable_queue() {
 fn test_subscription_options_broker_specific_headers() {
     // ActiveMQ durable subscription pattern
     let opts = SubscriptionOptions {
-        durable_queue: None,
         headers: vec![
             (
                 "activemq.subscriptionName".to_string(),
@@ -134,16 +116,13 @@ fn test_subscription_options_ergonomics() {
     // Default should provide empty options
     let default_opts = SubscriptionOptions::default();
     assert!(default_opts.headers.is_empty());
-    assert!(default_opts.durable_queue.is_none());
 
     // Clone should preserve all fields
     let opts = SubscriptionOptions {
-        durable_queue: Some("/queue/test".to_string()),
         headers: vec![("key".to_string(), "value".to_string())],
     };
 
     let cloned = opts.clone();
-    assert_eq!(opts.durable_queue, cloned.durable_queue);
     assert_eq!(opts.headers, cloned.headers);
 }
 
@@ -297,7 +276,6 @@ fn test_durable_subscription_example_compiles() {
         //         ("activemq.subscriptionName".into(), "my-durable-sub".into()),
         //         ("selector".into(), "priority > 5".into()),
         //     ],
-        //     durable_queue: None,
         // };
         //
         // let sub = conn.subscribe_with_options(

--- a/tests/subscription_stream.rs
+++ b/tests/subscription_stream.rs
@@ -14,7 +14,6 @@ use iridium_stomp::SubscriptionOptions;
 fn subscription_options_default() {
     let opts = SubscriptionOptions::default();
     assert!(opts.headers.is_empty());
-    assert!(opts.durable_queue.is_none());
 }
 
 #[test]
@@ -27,7 +26,6 @@ fn subscription_options_with_headers() {
             ),
             ("selector".to_string(), "priority > 5".to_string()),
         ],
-        durable_queue: None,
     };
     assert_eq!(opts.headers.len(), 2);
     assert_eq!(opts.headers[0].0, "activemq.subscriptionName");
@@ -35,31 +33,19 @@ fn subscription_options_with_headers() {
 }
 
 #[test]
-fn subscription_options_with_durable_queue() {
-    let opts = SubscriptionOptions {
-        headers: vec![],
-        durable_queue: Some("/queue/durable-test".to_string()),
-    };
-    assert_eq!(opts.durable_queue, Some("/queue/durable-test".to_string()));
-}
-
-#[test]
 fn subscription_options_clone() {
     let original = SubscriptionOptions {
         headers: vec![("key".to_string(), "value".to_string())],
-        durable_queue: Some("/queue/test".to_string()),
     };
     let cloned = original.clone();
 
     assert_eq!(original.headers, cloned.headers);
-    assert_eq!(original.durable_queue, cloned.durable_queue);
 }
 
 #[test]
 fn subscription_options_debug() {
     let opts = SubscriptionOptions {
         headers: vec![("test".to_string(), "value".to_string())],
-        durable_queue: None,
     };
     let debug_str = format!("{:?}", opts);
     assert!(debug_str.contains("SubscriptionOptions"));
@@ -78,11 +64,9 @@ fn subscription_options_full_config() {
             ("activemq.noLocal".to_string(), "true".to_string()),
             ("selector".to_string(), "type = 'important'".to_string()),
         ],
-        durable_queue: Some("/queue/events".to_string()),
     };
 
     assert_eq!(opts.headers.len(), 3);
-    assert_eq!(opts.durable_queue.as_deref(), Some("/queue/events"));
 }
 
 // =============================================================================
@@ -96,7 +80,6 @@ fn subscription_options_empty_header_values() {
             ("empty-value".to_string(), "".to_string()),
             ("".to_string(), "empty-key".to_string()),
         ],
-        durable_queue: None,
     };
     assert_eq!(opts.headers[0].1, "");
     assert_eq!(opts.headers[1].0, "");
@@ -109,8 +92,6 @@ fn subscription_options_special_characters() {
             "selector".to_string(),
             "id > 100 AND type = 'test'".to_string(),
         )],
-        durable_queue: Some("/queue/test?param=value&other=123".to_string()),
     };
     assert!(opts.headers[0].1.contains("'test'"));
-    assert!(opts.durable_queue.as_ref().unwrap().contains("?param="));
 }


### PR DESCRIPTION
Closes #91.

`SubscriptionOptions::durable_queue` read as though it requested a durable subscription. It did not. Its entire implementation in `subscribe_with_options` was a destination override:

```rust
let dest = options.durable_queue.as_deref().unwrap_or(destination);
```

Someone wanting an ActiveMQ durable topic subscription would reasonably set the field and silently get a plain, non-durable one — against a *different* destination than the one they passed. STOMP gives a broker no way to reject a "wrong" subscription header, so the SUBSCRIBE was accepted without complaint. The subscription looked healthy; the only symptom was messages quietly failing to persist across a disconnect.

Durability is requested through `SubscriptionOptions::headers`, using whatever header the broker defines (`activemq.subscriptionName` and friends). The struct-level rustdoc already said this — only the field disagreed with it.

## Why removed rather than deprecated

The issue proposed a deprecation cycle. I went with outright removal because the field's failure mode is silence: a compile error names every call site, whereas a warning is easy to scroll past — and `#[deprecated]` on a field fires even on `durable_queue: None`, which trains people to ignore it. 0.5.0 already carries breaking changes, so this costs a migration line rather than its own release.

## Migration

Move the value into the `destination` argument. A call that passed `durable_queue` was only ever subscribing to that value anyway:

```rust
// before — subscribes to /queue/y; the /exchange/x argument is discarded
let opts = SubscriptionOptions { durable_queue: Some("/queue/y".into()), headers: vec![] };
conn.subscribe_with_options("/exchange/x", ack, opts).await?;

// after
let opts = SubscriptionOptions { headers: vec![] };
conn.subscribe_with_options("/queue/y", ack, opts).await?;
```

## What to look at

The code change is small — `src/subscription.rs` and one `unwrap_or` in `src/connection.rs`. **The docs are the bulk of this PR, and are where the actual damage was.** They taught the misunderstanding rather than merely mentioning the field:

- `docs/durable_subscriptions.md` presented `durable_queue` as the RabbitMQ durability mechanism. Durability there is a property of the administratively declared queue, so the guide now just subscribes to it by name — no options at all, which is the clearest statement of what the field was hiding.
- `examples/subscribe.rs` passed `/exchange/topic` as the destination while setting `durable_queue` to `/queue/example-durable`. It silently subscribed to the queue and ignored the exchange — a working demonstration of the confusion, in an example whose job is to teach the API.
- `docs/subscriptions.md` drops the field from its options table and gains a note that STOMP has no durable-subscription concept of its own, so durability is whatever the broker defines it to be.

Tests whose only subject was the field (`test_subscription_options_durable_queue`, `subscription_options_with_durable_queue`) are deleted rather than adapted — there is nothing left for them to assert. The rest just drop it from their struct literals.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib` (22), `subscription_stream` (7), `subscribe_api_integration` (12), examples build, and 100% rustdoc coverage on the library — all green. No `durable_queue` references remain outside the historical changelog entries, which are left alone because they record what shipped at the time.

## Note

Branched from `main`, so it does not depend on #81. Both touch `CHANGELOG.md` under `[Unreleased]`; whichever merges second wants a trivial rebase there.