### PR TITLE
Issue 93 oneshot send

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,12 @@ jobs:
         run: |
           cargo test --lib --verbose
 
+      # The CLI lives behind the `cli` feature, so `--lib` never builds it and
+      # its tests would otherwise be written but never run.
+      - name: Run CLI tests
+        run: |
+          cargo test --test cli_oneshot --features cli --verbose
+
   build-examples:
     name: Build examples
     needs: [format, clippy, unit-tests]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `stomp --send <DESTINATION> <BODY>` sends one message and exits, without starting the interactive client ([#93])
+  - The CLI previously scripted only by closing stdin and driving the REPL through a pipe, which could not report whether the broker accepted the message.
+  - The message carries a receipt request and the tool waits for the answer, so the exit code is meaningful: 0 confirmed, 4 rejected (`FRAME_REJECTED`, which no CLI path could previously reach because nothing requested a receipt), 3 unanswered, 1 unreachable.
+  - `--timeout <SECONDS>` (default 5) bounds the whole operation. It also bounds the connection, which matters more than it appears: `Connection::connect` retries an unreachable broker indefinitely (see [#68]), so without this a `--send` at a dead broker would never return — as `stomp -a <dead> < /dev/null` still does not today.
+  - `--send` conflicts with `--tui`, `--subscribe`, and `--summary`, which belong to the interactive client.
+
 - `Connection::close` performs the STOMP 1.2 shutdown sequence ([#81])
   - It now sends a DISCONNECT frame carrying a `receipt` header, waits for the broker's RECEIPT, and only then stops the background task and closes the socket. Previously the broker saw a bare TCP FIN and could not distinguish a graceful exit from a crashed client, so anything it does on protocol-level disconnect — transactional rollback, durable subscription cleanup, audit logging — may not have run.
   - A confirmed close also proves that everything previously sent on the connection reached the broker. Frames are written in the order submitted and the broker answers the DISCONNECT only after processing what came before, so awaiting the receipt drains the outbound queue. This closes a gap where a frame submitted immediately before `close` could be abandoned at the shutdown signal — reachable from the CLI by issuing `send` and then `quit`.
@@ -253,6 +259,8 @@ Every breaking change in this release is listed here, with its migration.
 [#72]: https://github.com/iridiumdesign/iridium-stomp/pull/72
 [#73]: https://github.com/iridiumdesign/iridium-stomp/pull/73
 [#81]: https://github.com/iridiumdesign/iridium-stomp/issues/81
+[#68]: https://github.com/iridiumdesign/iridium-stomp/issues/68
 [#82]: https://github.com/iridiumdesign/iridium-stomp/issues/82
 [#91]: https://github.com/iridiumdesign/iridium-stomp/issues/91
+[#93]: https://github.com/iridiumdesign/iridium-stomp/issues/93
 [#96]: https://github.com/iridiumdesign/iridium-stomp/issues/96

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,8 @@ Run unit tests
 cargo test --lib
 ```
 
+Run the CLI tests (gated behind the `cli` feature, so `--lib` never builds them)
+```
+cargo test --test cli_oneshot --features cli
+```
+

--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ stomp -s /queue/orders -s /queue/notifications
 
 # Enable TUI mode for live monitoring
 stomp --tui -a 127.0.0.1:61613 -s /topic/events
+
+# Send one message and exit; the exit code says whether the broker took it
+stomp -a 127.0.0.1:61613 --send /queue/test 'hello'
 ```
 
 ### TUI Mode

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,8 @@ cargo run --features cli --bin stomp -- --help
 | `-s, --subscribe` | *(none)* | Destination to subscribe to on connect (repeatable) |
 | `--tui` | off | Enable TUI mode |
 | `--summary` | off | Print session summary on exit |
+| `--send <DESTINATION> <BODY>` | *(none)* | Send one message and exit, without starting the interactive client |
+| `--timeout <SECONDS>` | `5` | How long a `--send` waits on the broker, covering both the connection and the receipt |
 
 ```bash
 # Connect with defaults
@@ -45,6 +47,41 @@ stomp -a broker.example.com:61613 -l myuser -p mypass \
 # TUI mode with faster heartbeats
 stomp --tui --heartbeat 5000,5000 -s /queue/tasks
 ```
+
+---
+
+## One-shot send
+
+`stomp` is an interactive client; `--send` is its non-interactive side path.
+It connects, publishes one message, disconnects, and exits — no REPL, no pipe
+tricks:
+
+```bash
+stomp -a broker.example.com:61613 --send /queue/orders 'hello'
+```
+
+The message is sent with a receipt request and the tool waits for the broker's
+answer, so the exit code is worth testing:
+
+```bash
+if stomp --send /queue/orders "$payload"; then
+    echo "the broker has it"
+fi
+```
+
+| Exit | Meaning |
+|------|---------|
+| 0 | The broker confirmed the message |
+| 1 | Could not reach the broker within `--timeout` |
+| 3 | The broker did not answer within `--timeout`, or the destination was malformed |
+| 4 | The broker rejected the message (permissions, unknown destination) |
+
+`--timeout` bounds the whole operation. It matters more than it looks: a normal
+`Connection` retries an unreachable broker indefinitely, which is right for a
+long-lived service and wrong for a script, so `--send` gives up instead.
+
+`--send` cannot be combined with `--tui`, `-s/--subscribe`, or `--summary`;
+those belong to the interactive client.
 
 ---
 
@@ -197,4 +234,4 @@ The `--summary` flag prints the session summary automatically on exit.
 | 0 | SUCCESS | Normal exit |
 | 1 | NETWORK_ERROR | Connection refused, timeout, or network failure |
 | 2 | AUTH_ERROR | Authentication failed (bad credentials) |
-| 3 | PROTOCOL_ERROR | Unexpected server response or protocol violation |
+| 3 | PROTOCOL_ERROR | Unexpected server response, protocol violation, or a `--send` the broker never answered |

--- a/src/bin/cli/args.rs
+++ b/src/bin/cli/args.rs
@@ -32,4 +32,22 @@ pub struct Cli {
     /// Show session summary on exit
     #[arg(long)]
     pub summary: bool,
+
+    /// Send one message, then exit without starting the interactive client.
+    ///
+    /// The message is sent with a receipt request, so the exit code reflects
+    /// whether the broker accepted it: 0 confirmed, 4 rejected, 3 no answer
+    /// within --timeout.
+    #[arg(
+        long,
+        num_args = 2,
+        value_names = ["DESTINATION", "BODY"],
+        conflicts_with_all = ["tui", "subscribe", "summary"],
+    )]
+    pub send: Option<Vec<String>>,
+
+    /// Seconds to wait for the broker during a --send, covering both the
+    /// connection and the receipt
+    #[arg(long, default_value_t = 5, requires = "send", value_name = "SECONDS")]
+    pub timeout: u64,
 }

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod commands;
+pub mod oneshot;
 pub mod plain;
 pub mod state;
 pub mod tui;

--- a/src/bin/cli/oneshot.rs
+++ b/src/bin/cli/oneshot.rs
@@ -1,0 +1,83 @@
+//! One-shot send: connect, publish a single message, disconnect, exit.
+//!
+//! This is the non-interactive side path of an interactive-first client. It
+//! exists so a script can publish a message and learn from the exit code
+//! whether the broker took it, without driving the REPL through a pipe.
+
+use iridium_stomp::{ConnectOptions, Connection, Frame};
+use std::time::Duration;
+
+use super::args::Cli;
+use super::exit_codes;
+use super::plain::format_connection_error_pub;
+
+/// Send a single message and return once the broker has confirmed it.
+///
+/// # Parameters
+/// - `cli`: parsed arguments, for the broker address, credentials and timeout.
+/// - `destination`: the STOMP destination to publish to.
+/// - `body`: the message body, sent as `text/plain`.
+pub async fn run(cli: &Cli, destination: &str, body: &str) -> Result<(), (String, u8)> {
+    // Same guard the interactive `send` command applies, so a typo fails here
+    // rather than being silently accepted by the broker.
+    if !destination.starts_with('/') {
+        return Err((
+            format!(
+                "Invalid destination '{}'. Must start with / (e.g., /topic/test, /queue/test)",
+                destination
+            ),
+            exit_codes::PROTOCOL_ERROR,
+        ));
+    }
+
+    let timeout = Duration::from_secs(cli.timeout);
+    let options = ConnectOptions::default().disconnect_timeout(timeout);
+
+    // `Connection::connect` retries an unreachable broker indefinitely, which is
+    // right for a long-lived service and wrong for a script: without this bound
+    // a --send at a dead broker would never return. See issue #68.
+    let conn = tokio::time::timeout(
+        timeout,
+        Connection::connect_with_options(
+            &cli.address,
+            &cli.login,
+            &cli.passcode,
+            &cli.heartbeat,
+            options,
+        ),
+    )
+    .await
+    .map_err(|_| {
+        (
+            format!(
+                "Timed out after {}s connecting to {}",
+                cli.timeout, cli.address
+            ),
+            exit_codes::NETWORK_ERROR,
+        )
+    })?
+    .map_err(|e| format_connection_error_pub(&e, &cli.address))?;
+
+    let frame = Frame::new("SEND")
+        .header("destination", destination)
+        .header("content-type", "text/plain")
+        .set_body(body.as_bytes().to_vec());
+
+    // Confirmed rather than fire-and-forget: an exit code that does not depend
+    // on the broker having accepted the message would not be worth reporting.
+    let sent = conn
+        .send_frame_confirmed(frame, timeout)
+        .await
+        .map_err(|e| format_connection_error_pub(&e, &cli.address));
+
+    // Disconnect cleanly whatever the send did, but let the send's outcome win:
+    // it is what the caller asked about.
+    let closed = conn.close().await;
+    sent?;
+    if let Err(e) = closed {
+        eprintln!("Warning: broker did not confirm the disconnect: {}", e);
+    }
+
+    println!("Sent to {}", destination);
+    Ok(())
+}

--- a/src/bin/stomp.rs
+++ b/src/bin/stomp.rs
@@ -10,7 +10,11 @@ use cli::exit_codes;
 async fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let result = if cli.tui {
+    // `--send` takes exactly two values, so the indexing below is what clap has
+    // already guaranteed.
+    let result = if let Some(send) = cli.send.clone() {
+        cli::oneshot::run(&cli, &send[0], &send[1]).await
+    } else if cli.tui {
         cli::tui::run(&cli).await
     } else {
         cli::plain::run(&cli).await

--- a/src/bin/stomp.rs
+++ b/src/bin/stomp.rs
@@ -12,7 +12,7 @@ async fn main() -> ExitCode {
 
     // `--send` takes exactly two values, so the indexing below is what clap has
     // already guaranteed.
-    let result = if let Some(send) = cli.send.clone() {
+    let result = if let Some(send) = cli.send.as_deref() {
         cli::oneshot::run(&cli, &send[0], &send[1]).await
     } else if cli.tui {
         cli::tui::run(&cli).await

--- a/tests/cli_oneshot.rs
+++ b/tests/cli_oneshot.rs
@@ -1,0 +1,260 @@
+//! Coverage for #93's one-shot send: `stomp --send <dest> <body>`.
+//!
+//! These drive the real binary, because the thing under test is the contract a
+//! script sees - the exit code - not an internal function. `CARGO_BIN_EXE_stomp`
+//! is set by cargo for integration tests.
+//!
+//! Requires the `cli` feature, which is what builds the binary at all.
+#![cfg(feature = "cli")]
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// How the stub broker should answer a SEND that requested a receipt.
+#[derive(Clone, Copy)]
+enum OnSend {
+    /// Confirm it, as a broker that accepted the message.
+    Receipt,
+    /// Reject it with an ERROR carrying the receipt id, as a broker refusing
+    /// the publish (bad permissions, unknown destination).
+    Error,
+    /// Say nothing at all, as a broker that has stalled.
+    Silence,
+}
+
+/// Frames the broker saw, as raw text.
+type Seen = Arc<Mutex<Vec<String>>>;
+
+fn start_broker(on_send: OnSend) -> (String, Seen) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = seen.clone();
+
+    thread::spawn(move || {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        let mut buf = [0u8; 8192];
+
+        if stream.read(&mut buf).is_ok() {
+            let _ = stream.write_all(b"CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0");
+            let _ = stream.flush();
+        }
+
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let text = String::from_utf8_lossy(&buf[..n]).to_string();
+                    for raw in text.split('\0').filter(|f| !f.trim().is_empty()) {
+                        let raw = raw.trim_start().to_string();
+                        let command = raw.lines().next().unwrap_or("").to_string();
+                        seen_clone.lock().unwrap().push(raw.clone());
+
+                        let Some(id) = receipt_id_of(&raw) else {
+                            continue;
+                        };
+                        let reply = match (command.as_str(), on_send) {
+                            ("SEND", OnSend::Receipt) => {
+                                format!("RECEIPT\nreceipt-id:{}\n\n\0", id)
+                            }
+                            ("SEND", OnSend::Error) => format!(
+                                "ERROR\nreceipt-id:{}\nmessage:publish denied\n\n{}\0",
+                                id, "not allowed"
+                            ),
+                            ("SEND", OnSend::Silence) => continue,
+                            // Always answer the DISCONNECT so teardown is not
+                            // what the timing tests end up measuring.
+                            ("DISCONNECT", _) => format!("RECEIPT\nreceipt-id:{}\n\n\0", id),
+                            _ => continue,
+                        };
+                        let _ = stream.write_all(reply.as_bytes());
+                        let _ = stream.flush();
+                    }
+                }
+            }
+        }
+    });
+
+    (addr, seen)
+}
+
+fn receipt_id_of(frame: &str) -> Option<&str> {
+    frame.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        key.eq_ignore_ascii_case("receipt").then_some(value)
+    })
+}
+
+fn commands(seen: &Seen) -> Vec<String> {
+    seen.lock()
+        .unwrap()
+        .iter()
+        .map(|f| f.lines().next().unwrap_or("").to_string())
+        .collect()
+}
+
+fn stomp(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_stomp"))
+        .args(args)
+        .output()
+        .expect("failed to run the stomp binary")
+}
+
+/// Exit codes from `src/bin/cli/mod.rs::exit_codes`.
+const SUCCESS: i32 = 0;
+const NETWORK_ERROR: i32 = 1;
+const PROTOCOL_ERROR: i32 = 3;
+const FRAME_REJECTED: i32 = 4;
+
+#[test]
+fn send_confirmed_by_the_broker_exits_zero() {
+    let (addr, seen) = start_broker(OnSend::Receipt);
+
+    let out = stomp(&["-a", &addr, "--send", "/queue/orders", "hello"]);
+
+    assert_eq!(out.status.code(), Some(SUCCESS), "stderr: {}", stderr(&out));
+
+    let cmds = commands(&seen);
+    assert_eq!(
+        cmds,
+        vec!["SEND", "DISCONNECT"],
+        "a one-shot should publish and then disconnect cleanly"
+    );
+
+    let send = seen.lock().unwrap()[0].clone();
+    assert!(
+        send.contains("destination:/queue/orders"),
+        "frame: {}",
+        send
+    );
+    assert!(send.contains("hello"), "body missing from frame: {}", send);
+    assert!(
+        receipt_id_of(&send).is_some(),
+        "the SEND must request a receipt, or the exit code means nothing: {}",
+        send
+    );
+}
+
+#[test]
+fn send_rejected_by_the_broker_exits_frame_rejected() {
+    let (addr, _seen) = start_broker(OnSend::Error);
+
+    let out = stomp(&["-a", &addr, "--send", "/queue/forbidden", "payload"]);
+
+    assert_eq!(
+        out.status.code(),
+        Some(FRAME_REJECTED),
+        "a broker refusing the publish must not look like success. stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn send_to_a_silent_broker_times_out_rather_than_hanging() {
+    let (addr, _seen) = start_broker(OnSend::Silence);
+
+    let started = Instant::now();
+    let out = stomp(&[
+        "-a",
+        &addr,
+        "--send",
+        "/queue/x",
+        "payload",
+        "--timeout",
+        "1",
+    ]);
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        out.status.code(),
+        Some(PROTOCOL_ERROR),
+        "stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "--timeout must bound the wait (took {:?})",
+        elapsed
+    );
+}
+
+#[test]
+fn send_to_an_unreachable_broker_times_out_rather_than_retrying_forever() {
+    // Connection::connect retries indefinitely (#68), so without an explicit
+    // bound in the one-shot path this would never return.
+    let started = Instant::now();
+    let out = stomp(&[
+        "-a",
+        "127.0.0.1:59999",
+        "--send",
+        "/queue/x",
+        "payload",
+        "--timeout",
+        "2",
+    ]);
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        out.status.code(),
+        Some(NETWORK_ERROR),
+        "stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "a dead broker must fail fast, not retry forever (took {:?})",
+        elapsed
+    );
+}
+
+#[test]
+fn send_rejects_a_destination_that_is_not_a_path() {
+    let (addr, _seen) = start_broker(OnSend::Receipt);
+
+    let out = stomp(&["-a", &addr, "--send", "queue/no-leading-slash", "payload"]);
+
+    assert_eq!(
+        out.status.code(),
+        Some(PROTOCOL_ERROR),
+        "stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("Must start with /"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn send_conflicts_with_the_interactive_modes() {
+    // --send is the non-interactive side path; combining it with the TUI or a
+    // subscription is a mistake worth naming rather than silently resolving.
+    for extra in [vec!["--tui"], vec!["-s", "/queue/x"], vec!["--summary"]] {
+        let mut args = vec!["-a", "127.0.0.1:59999", "--send", "/queue/x", "payload"];
+        args.extend(extra.iter());
+        let out = stomp(&args);
+        assert!(
+            !out.status.success(),
+            "expected {:?} to be rejected alongside --send",
+            extra
+        );
+        assert!(
+            stderr(&out).contains("cannot be used with"),
+            "expected a conflict error for {:?}, got: {}",
+            extra,
+            stderr(&out)
+        );
+    }
+}
+
+fn stderr(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}

--- a/tests/cli_oneshot.rs
+++ b/tests/cli_oneshot.rs
@@ -47,13 +47,24 @@ fn start_broker(on_send: OnSend) -> (String, Seen) {
             let _ = stream.flush();
         }
 
+        // TCP is a byte stream, so a single read may carry a partial frame or
+        // several at once. Accumulate bytes and act only on complete,
+        // NUL-terminated frames; a partial trailing frame waits in `acc` for
+        // the rest to arrive.
+        let mut acc: Vec<u8> = Vec::new();
         loop {
             match stream.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(n) => {
-                    let text = String::from_utf8_lossy(&buf[..n]).to_string();
-                    for raw in text.split('\0').filter(|f| !f.trim().is_empty()) {
-                        let raw = raw.trim_start().to_string();
+                    acc.extend_from_slice(&buf[..n]);
+                    while let Some(pos) = acc.iter().position(|&b| b == 0) {
+                        let frame: Vec<u8> = acc.drain(..=pos).collect();
+                        let text = String::from_utf8_lossy(&frame);
+                        let raw = text.trim_matches('\0').trim_start();
+                        if raw.trim().is_empty() {
+                            continue;
+                        }
+                        let raw = raw.to_string();
                         let command = raw.lines().next().unwrap_or("").to_string();
                         seen_clone.lock().unwrap().push(raw.clone());
 


### PR DESCRIPTION
This pull request introduces a new non-interactive "one-shot send" mode to the CLI, allowing users (and scripts) to send a single message to a STOMP broker and exit with a meaningful status code. This is implemented via the new `--send <DESTINATION> <BODY>` flag, which ensures the message is confirmed by the broker (or reports failure) and is bounded by a configurable timeout. The change includes documentation updates, new tests, and the necessary CLI and code modifications.

**New CLI feature: One-shot send**

* Added the `--send <DESTINATION> <BODY>` flag to the CLI, allowing users to send a single message and exit without starting the interactive client. The command waits for a broker receipt and exits with a meaningful code: 0 (confirmed), 4 (rejected), 3 (no answer), 1 (unreachable). The operation is bounded by a new `--timeout` option (default 5s), which also limits connection attempts. `--send` conflicts with `--tui`, `--subscribe`, and `--summary`. (`src/bin/cli/args.rs`, `src/bin/cli/oneshot.rs`, `src/bin/stomp.rs`, [[1]](diffhunk://#diff-a004366482fcae8ae3e3f98ace8138c09071682f0e86452009dcfb06797a4700R35-R52) [[2]](diffhunk://#diff-386cce218f136c4bb5a686cf1cc42c8e739052eebd74535e3b59dfd07526ae38R1-R83) [[3]](diffhunk://#diff-a895476ef0668f88c56299b58a7e865f7a9c8555dfbb769bae9a28d60189ab99L13-R17)

**Documentation and usage updates**

* Updated documentation to describe the new `--send` and `--timeout` options, including usage examples, exit code meanings, and conflict rules. (`docs/cli.md`, `README.md`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R17) [[2]](diffhunk://#diff-27c8c22b45605a0ddf42ce8017b6b2a68cb3b10534c18bf4a781e230d7b92361R36-R37) [[3]](diffhunk://#diff-27c8c22b45605a0ddf42ce8017b6b2a68cb3b10534c18bf4a781e230d7b92361R53-R87) [[4]](diffhunk://#diff-27c8c22b45605a0ddf42ce8017b6b2a68cb3b10534c18bf4a781e230d7b92361L200-R237) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R367-R369)
* Updated the changelog to record the new feature and its behavior, including references to related issues. (`CHANGELOG.md`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R17) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR262-R265)

**Testing and CI improvements**

* Added a new integration test, `cli_oneshot.rs`, covering all exit code paths and broker behaviors for the one-shot send feature. (`tests/cli_oneshot.rs`, [tests/cli_oneshot.rsR1-R260](diffhunk://#diff-c231a6a5ab9a25da67d8a3b354cec6bce93253f1819118be763002cbe0174941R1-R260))
* Updated the CI workflow to build and run the new CLI tests gated by the `cli` feature. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlR174-R179](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR174-R179))
* Updated contributor documentation to explain how to run the new CLI tests. (`CLAUDE.md`, [CLAUDE.mdR27-R31](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R27-R31))

Closes #93