### PR TITLE
feat(connection): bound the initial connect with ConnectOptions::conn…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ConnectOptions::connect_timeout` bounds the initial connect and handshake ([#68])
   - `Connection::connect` retries an unreachable broker indefinitely with exponential backoff — the right default for a long-lived service that should wait for its broker to come up, but the wrong one for a CLI tool or one-shot script pointed at a misconfigured address, which hangs forever with no way to bail out short of wrapping the call in `tokio::time::timeout`.
-  - When set, the whole operation is bounded; on expiry `connect_with_options` returns the last `ConnError::Io` it encountered (or a synthesized `ErrorKind::TimedOut` if the first attempt had not yet produced one). A `ServerRejected` still fails immediately, before the bound, because retrying bad credentials is pointless.
+  - When set, the whole operation is bounded; on expiry `connect_with_options` returns the last error it encountered — a `ConnError::Io`, or a `ConnError::Protocol` from a broker that closed the socket mid-handshake — or a synthesized `ErrorKind::TimedOut` if no attempt had produced one yet. A `ServerRejected` still fails immediately, before the bound, because retrying bad credentials is pointless.
   - Defaults to `None`, preserving the retry-forever behaviour for existing callers.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A confirmed close also proves that everything previously sent on the connection reached the broker. Frames are written in the order submitted and the broker answers the DISCONNECT only after processing what came before, so awaiting the receipt drains the outbound queue. This closes a gap where a frame submitted immediately before `close` could be abandoned at the shutdown signal — reachable from the CLI by issuing `send` and then `quit`.
 - `ConnectOptions::disconnect_timeout` bounds that wait, defaulting to `Connection::DEFAULT_DISCONNECT_TIMEOUT` (5 seconds) ([#81])
 
+- `ConnectOptions::connect_timeout` bounds the initial connect and handshake ([#68])
+  - `Connection::connect` retries an unreachable broker indefinitely with exponential backoff — the right default for a long-lived service that should wait for its broker to come up, but the wrong one for a CLI tool or one-shot script pointed at a misconfigured address, which hangs forever with no way to bail out short of wrapping the call in `tokio::time::timeout`.
+  - When set, the whole operation is bounded; on expiry `connect_with_options` returns the last `ConnError::Io` it encountered (or a synthesized `ErrorKind::TimedOut` if the first attempt had not yet produced one). A `ServerRejected` still fails immediately, before the bound, because retrying bad credentials is pointless.
+  - Defaults to `None`, preserving the retry-forever behaviour for existing callers.
+
 ### Changed
 
 Every breaking change in this release is listed here, with its migration.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -399,7 +399,7 @@ pub struct ConnectOptions {
     /// [`Connection::connect_with_options`] gives up. When `None` (the
     /// default), an unreachable broker is retried indefinitely with backoff.
     /// When set, the whole operation is bounded and, on expiry, the last
-    /// I/O error encountered is returned.
+    /// error encountered is returned.
     pub connect_timeout: Option<Duration>,
 }
 
@@ -484,12 +484,12 @@ impl ConnectOptions {
     /// misconfigured address: without a bound it hangs forever. Set this to cap
     /// the whole operation.
     ///
-    /// When the timeout expires, `connect_with_options` returns the last
-    /// [`ConnError::Io`] it encountered (or a synthesized
-    /// [`std::io::ErrorKind::TimedOut`] if the first attempt had not yet
-    /// produced one). A `ConnError::ServerRejected` still fails immediately,
-    /// before the bound is consulted, because retrying bad credentials is
-    /// pointless.
+    /// When the timeout expires, `connect_with_options` returns the last error
+    /// it encountered — a [`ConnError::Io`], or a [`ConnError::Protocol`] such
+    /// as a broker that closed the socket mid-handshake — or a synthesized
+    /// [`std::io::ErrorKind::TimedOut`] if no attempt had produced one yet. A
+    /// `ConnError::ServerRejected` still fails immediately, before the bound is
+    /// consulted, because retrying bad credentials is pointless.
     ///
     /// # Example
     ///
@@ -940,7 +940,7 @@ impl Connection {
         // using the same strategy as reconnection. Only ServerRejected
         // (authentication failure) fails immediately.
         //
-        // `last_err` remembers the most recent I/O failure so that, if a
+        // `last_err` remembers the most recent failure so that, if a
         // `connect_timeout` bound elapses, the caller gets that error rather
         // than a bare "timed out". It is written by the retry arms and read
         // only after the attempt future below has been dropped.
@@ -1025,7 +1025,7 @@ impl Connection {
             Some(timeout) => match tokio::time::timeout(timeout, attempt).await {
                 Ok(result) => result?,
                 Err(_elapsed) => {
-                    // The bound elapsed. Hand back the last I/O error seen, or
+                    // The bound elapsed. Hand back the last error seen, or
                     // synthesize a timeout if the very first attempt was still
                     // in flight and had not recorded one yet.
                     return Err(last_err.unwrap_or_else(|| {
@@ -2266,6 +2266,40 @@ mod tests {
             "connect should have given up near the 200ms bound, took {:?}",
             elapsed
         );
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_surfaces_the_last_handshake_error() {
+        // A broker that accepts the TCP connection then closes without ever
+        // sending CONNECTED — a TLS-only port, say. The handshake fails with
+        // ConnError::Protocol ("closed before CONNECTED received"), and the
+        // bound must surface that real reason rather than a synthesized
+        // timeout.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _connect = read_stomp_frame(&mut stream);
+                // Drop the stream without answering: closed mid-handshake.
+            }
+        });
+
+        let result = Connection::connect_with_options(
+            &addr.to_string(),
+            "guest",
+            "guest",
+            "0,0",
+            ConnectOptions::default().connect_timeout(Duration::from_millis(200)),
+        )
+        .await;
+
+        let err = result.err();
+        assert!(
+            matches!(err, Some(ConnError::Protocol(_))),
+            "expected the handshake Protocol error, got {:?}",
+            err
+        );
+        handle.join().unwrap();
     }
 
     #[tokio::test]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -394,6 +394,13 @@ pub struct ConnectOptions {
     /// sends DISCONNECT. Defaults to
     /// [`Connection::DEFAULT_DISCONNECT_TIMEOUT`] if not set.
     pub disconnect_timeout: Option<Duration>,
+
+    /// Upper bound on the initial connect-and-handshake before
+    /// [`Connection::connect_with_options`] gives up. When `None` (the
+    /// default), an unreachable broker is retried indefinitely with backoff.
+    /// When set, the whole operation is bounded and, on expiry, the last
+    /// I/O error encountered is returned.
+    pub connect_timeout: Option<Duration>,
 }
 
 impl std::fmt::Debug for ConnectOptions {
@@ -408,6 +415,7 @@ impl std::fmt::Debug for ConnectOptions {
                 &self.heartbeat_tx.as_ref().map(|_| "Some(...)"),
             )
             .field("disconnect_timeout", &self.disconnect_timeout)
+            .field("connect_timeout", &self.connect_timeout)
             .finish()
     }
 }
@@ -464,6 +472,33 @@ impl ConnectOptions {
     /// ```
     pub fn disconnect_timeout(mut self, timeout: Duration) -> Self {
         self.disconnect_timeout = Some(timeout);
+        self
+    }
+
+    /// Bound the initial connect and STOMP handshake (builder style).
+    ///
+    /// By default [`Connection::connect_with_options`] retries an unreachable
+    /// broker indefinitely with exponential backoff, which is the right choice
+    /// for a long-lived service that should wait for its broker to come up. It
+    /// is the wrong choice for a CLI tool or one-shot script pointed at a
+    /// misconfigured address: without a bound it hangs forever. Set this to cap
+    /// the whole operation.
+    ///
+    /// When the timeout expires, `connect_with_options` returns the last
+    /// [`ConnError::Io`] it encountered (or a synthesized
+    /// [`std::io::ErrorKind::TimedOut`] if the first attempt had not yet
+    /// produced one). A `ConnError::ServerRejected` still fails immediately,
+    /// before the bound is consulted, because retrying bad credentials is
+    /// pointless.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let options = ConnectOptions::default()
+    ///     .connect_timeout(Duration::from_secs(60));
+    /// ```
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
         self
     }
 
@@ -839,6 +874,10 @@ impl Connection {
     /// reconnection after a connection drop. This means your application can
     /// start before the broker is available and will connect once it comes up.
     ///
+    /// This retry is unbounded by default. Set
+    /// [`ConnectOptions::connect_timeout`] to cap it — useful for CLI tools and
+    /// one-shot scripts that must not hang forever on a misconfigured address.
+    ///
     /// # Errors
     ///
     /// Returns an error immediately (no retry) if:
@@ -893,81 +932,111 @@ impl Connection {
         let client_id = options.client_id;
         let custom_headers = options.headers;
         let heartbeat_notify_tx = options.heartbeat_tx;
+        let connect_timeout = options.connect_timeout;
 
         // Perform initial connection and STOMP handshake before spawning
         // background task. Retries with exponential backoff on I/O and
         // protocol errors (broker unreachable or crashing mid-handshake)
         // using the same strategy as reconnection. Only ServerRejected
         // (authentication failure) fails immediately.
+        //
+        // `last_err` remembers the most recent I/O failure so that, if a
+        // `connect_timeout` bound elapses, the caller gets that error rather
+        // than a bare "timed out". It is written by the retry arms and read
+        // only after the attempt future below has been dropped.
         let mut backoff_secs: u64 = 1;
-        let (framed, send_interval, recv_interval) = loop {
-            let stream = match TcpStream::connect(&addr).await {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(
-                        addr = %addr,
-                        error = %e,
-                        backoff_secs,
-                        "initial connect failed, retrying in {}s",
-                        backoff_secs,
-                    );
-                    tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
-                    backoff_secs = (backoff_secs * 2).min(30);
-                    continue;
-                }
-            };
-            let mut framed = Framed::new(stream, StompCodec::new());
+        let mut last_err: Option<ConnError> = None;
+        let attempt = async {
+            loop {
+                let stream = match TcpStream::connect(&addr).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(
+                            addr = %addr,
+                            error = %e,
+                            backoff_secs,
+                            "initial connect failed, retrying in {}s",
+                            backoff_secs,
+                        );
+                        last_err = Some(ConnError::Io(e));
+                        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                        backoff_secs = (backoff_secs * 2).min(30);
+                        continue;
+                    }
+                };
+                let mut framed = Framed::new(stream, StompCodec::new());
 
-            let connect = Self::build_connect_frame(
-                &accept_version,
-                &host,
-                &login,
-                &passcode,
-                &client_hb,
-                &client_id,
-                &custom_headers,
-            );
-
-            if let Err(e) = framed.send(StompItem::Frame(connect)).await {
-                tracing::warn!(
-                    addr = %addr,
-                    error = %e,
-                    backoff_secs,
-                    "failed to send CONNECT frame, retrying in {}s",
-                    backoff_secs,
+                let connect = Self::build_connect_frame(
+                    &accept_version,
+                    &host,
+                    &login,
+                    &passcode,
+                    &client_hb,
+                    &client_id,
+                    &custom_headers,
                 );
-                tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
-                backoff_secs = (backoff_secs * 2).min(30);
-                continue;
-            }
 
-            match Self::await_connected_response(&mut framed).await {
-                Ok(server_hb) => {
-                    tracing::info!(addr = %addr, "connected to broker");
-                    let (cx, cy) = parse_heartbeat_header(&client_hb);
-                    let (sx, sy) = parse_heartbeat_header(&server_hb);
-                    let (si, ri) = negotiate_heartbeats(cx, cy, sx, sy);
-                    break (framed, si, ri);
-                }
-                // Auth errors fail immediately — bad config should not be retried
-                Err(e @ ConnError::ServerRejected(_)) => {
-                    return Err(e);
-                }
-                // I/O and protocol errors during handshake (e.g., broker
-                // crashed or closed mid-handshake) — retry with backoff
-                Err(e) => {
+                if let Err(e) = framed.send(StompItem::Frame(connect)).await {
                     tracing::warn!(
                         addr = %addr,
                         error = %e,
                         backoff_secs,
-                        "handshake failed, retrying in {}s",
+                        "failed to send CONNECT frame, retrying in {}s",
                         backoff_secs,
                     );
+                    last_err = Some(ConnError::Io(e));
                     tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                     backoff_secs = (backoff_secs * 2).min(30);
                     continue;
                 }
+
+                match Self::await_connected_response(&mut framed).await {
+                    Ok(server_hb) => {
+                        tracing::info!(addr = %addr, "connected to broker");
+                        let (cx, cy) = parse_heartbeat_header(&client_hb);
+                        let (sx, sy) = parse_heartbeat_header(&server_hb);
+                        let (si, ri) = negotiate_heartbeats(cx, cy, sx, sy);
+                        return Ok::<_, ConnError>((framed, si, ri));
+                    }
+                    // Auth errors fail immediately — bad config should not be retried
+                    Err(e @ ConnError::ServerRejected(_)) => {
+                        return Err(e);
+                    }
+                    // I/O and protocol errors during handshake (e.g., broker
+                    // crashed or closed mid-handshake) — retry with backoff
+                    Err(e) => {
+                        tracing::warn!(
+                            addr = %addr,
+                            error = %e,
+                            backoff_secs,
+                            "handshake failed, retrying in {}s",
+                            backoff_secs,
+                        );
+                        last_err = Some(e);
+                        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                        backoff_secs = (backoff_secs * 2).min(30);
+                        continue;
+                    }
+                }
             }
+        };
+
+        let (framed, send_interval, recv_interval) = match connect_timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, attempt).await {
+                Ok(result) => result?,
+                Err(_elapsed) => {
+                    // The bound elapsed. Hand back the last I/O error seen, or
+                    // synthesize a timeout if the very first attempt was still
+                    // in flight and had not recorded one yet.
+                    return Err(last_err.unwrap_or_else(|| {
+                        ConnError::Io(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("connect to {} timed out after {:?}", addr, timeout),
+                        ))
+                    }));
+                }
+            },
+            None => attempt.await?,
         };
 
         // Now spawn background task for ongoing I/O and reconnection.
@@ -2159,6 +2228,80 @@ mod tests {
         });
 
         (addr, handle)
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_bounds_an_unreachable_broker() {
+        // Bind, then drop the listener so the port is closed. A connect there
+        // is refused immediately, and without a bound the retry loop would back
+        // off and try again forever (#68). The bound must cut it short and hand
+        // back the last I/O error it saw, not hang.
+        let addr = {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap()
+        };
+
+        let start = std::time::Instant::now();
+        let result = Connection::connect_with_options(
+            &addr.to_string(),
+            "guest",
+            "guest",
+            "0,0",
+            ConnectOptions::default().connect_timeout(Duration::from_millis(200)),
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        // `Connection` is not `Debug`, so inspect the error side only.
+        let err = result.err();
+        assert!(
+            matches!(err, Some(ConnError::Io(_))),
+            "expected an Io error, got {:?}",
+            err
+        );
+        // The first refusal is instant; the bound fires during the 1s backoff
+        // sleep that follows, well under a second.
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "connect should have given up near the 200ms bound, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_does_not_disturb_a_reachable_broker() {
+        // A generous bound must not interfere with a broker that answers
+        // promptly: the connection still succeeds.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _connect = read_stomp_frame(&mut stream);
+                stream
+                    .write_all(b"CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0")
+                    .unwrap();
+                stream.flush().unwrap();
+                thread::sleep(Duration::from_millis(100));
+            }
+        });
+
+        let result = Connection::connect_with_options(
+            &addr.to_string(),
+            "guest",
+            "guest",
+            "0,0",
+            ConnectOptions::default()
+                .connect_timeout(Duration::from_secs(5))
+                .disconnect_timeout(Duration::from_millis(50)),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "expected a connection, got error {:?}",
+            result.as_ref().err()
+        );
+        handle.join().unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
…ect_timeout

Connection::connect retries an unreachable broker indefinitely with exponential backoff (#66). That is the right default for a long-lived service that should block until its broker comes up, but it means a CLI tool or one-shot script pointed at a misconfigured address hangs forever, with no way out short of wrapping the call in tokio::time::timeout and untangling the nested Result that produces.

  let options = ConnectOptions::new().connect_timeout(Duration::from_secs(60));

When set, the whole connect-and-handshake is bounded. On expiry connect_with_options returns the last ConnError::Io it encountered rather than a bare "timed out" - or a synthesized ErrorKind::TimedOut if the very first attempt was still in flight and had not recorded one yet. A ServerRejected still fails immediately, before the bound is consulted, because retrying bad credentials is pointless.

The bound wraps the whole attempt future rather than only checking between retries, so it also cuts off a connect that hangs - a blackholed address where TcpStream::connect never returns - which a between-retries check alone would miss. This matches the tokio::time::timeout workaround the issue documented, without the nested Result.

Defaults to None, preserving the retry-forever behaviour for every existing caller. This is the mechanism the interactive CLI needs to stop hanging at a dead broker (#101).

Tested against a closed port (returns Io within the bound, not a hang) and a reachable broker (a generous bound does not disturb a normal connect).

Closes #68