### PR TITLE
fix(codec): bound frame size to stop a malformed content-length crash…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The frame decoder rejected nothing on frame size, so a malicious or buggy broker could crash or exhaust any connected client. Two related fixes, both bounded by a new frame-size limit (`ConnectOptions::max_frame_size`, default 16 MiB):
+  - A `content-length` near `usize::MAX` overflowed the decoder's length arithmetic (`pos + content_len + 1`) — a debug-build panic, and in release a wrap past the bounds check followed by an out-of-range slice panic. Because the decoder runs on the connection's background task, a single crafted frame took the connection down. Oversized lengths are now rejected as a protocol error, and the remaining arithmetic is checked.
+  - A large-but-not-overflowing `content-length`, or a frame that never sent its terminating NUL, made the codec buffer without limit while waiting for bytes that never came. The codec now errors once a single frame exceeds the bound.
+  - All published 0.4.x releases are affected. There is no configuration to disable the guard; raise `max_frame_size` if you legitimately exchange messages larger than 16 MiB.
+
 ### Added
+
+- `ConnectOptions::max_frame_size` bounds the largest inbound frame, defaulting to `parser::DEFAULT_MAX_FRAME_SIZE` (16 MiB). See the Security note above.
 
 - `stomp --send <DESTINATION> <BODY>` sends one message and exits, without starting the interactive client ([#93])
   - The CLI previously scripted only by closing stdin and driving the REPL through a pipe, which could not report whether the broker accepted the message.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -3,7 +3,7 @@ use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::frame::Frame;
-use crate::parser::{parse_frame_slice, unescape_header_value};
+use crate::parser::{DEFAULT_MAX_FRAME_SIZE, parse_frame_slice_bounded, unescape_header_value};
 
 /// Escape a STOMP 1.2 header value for wire transmission.
 ///
@@ -50,13 +50,26 @@ pub enum StompItem {
 /// - Encode `StompItem` back into bytes for the wire format and emit
 ///   `content-length` when necessary.
 pub struct StompCodec {
-    // No internal buffer: we parse directly from the provided `src` buffer
+    // No internal buffer: we parse directly from the provided `src` buffer.
+    /// Largest frame this codec will decode before returning an error, in
+    /// bytes. Bounds both an oversized `content-length` and a frame that never
+    /// terminates, so neither can exhaust memory.
+    max_frame_size: usize,
 }
 
 impl StompCodec {
-    /// Create a new `StompCodec` instance.
+    /// Create a new `StompCodec` bounding frames at
+    /// [`DEFAULT_MAX_FRAME_SIZE`].
     pub fn new() -> Self {
-        Self {}
+        Self {
+            max_frame_size: DEFAULT_MAX_FRAME_SIZE,
+        }
+    }
+
+    /// Create a `StompCodec` that rejects any frame larger than
+    /// `max_frame_size` bytes.
+    pub fn with_max_frame_size(max_frame_size: usize) -> Self {
+        Self { max_frame_size }
     }
 }
 
@@ -85,17 +98,30 @@ impl Decoder for StompCodec {
     /// - `Err(io::Error)` on protocol or data errors (invalid UTF-8, malformed
     ///   frames, missing NUL after a content-length body, etc.).
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        // Move any newly-received bytes from the provided `src` into our
-        // internal buffer. We keep a separate buffer so parsing can proceed
-        // across arbitrary chunk boundaries without relying on indexes into
-        // heartbeat: single LF
-        if let Some(&b'\n') = src.chunk().first() {
-            src.advance(1);
-            return Ok(Some(StompItem::Heartbeat));
+        // Heartbeat: a STOMP 1.2 EOL, which is a bare LF or a CRLF. We parse
+        // directly from `src` (BytesMut is contiguous, so `chunk()` is the whole
+        // buffer); there is no separate accumulation buffer.
+        match src.chunk().first() {
+            Some(b'\n') => {
+                src.advance(1);
+                return Ok(Some(StompItem::Heartbeat));
+            }
+            Some(b'\r') => match src.chunk().get(1) {
+                Some(b'\n') => {
+                    src.advance(2);
+                    return Ok(Some(StompItem::Heartbeat));
+                }
+                // A lone CR so far: wait for the next byte to tell CRLF apart
+                // from the (malformed) start of a frame.
+                None => return Ok(None),
+                // CR followed by something else: let the frame parser judge it.
+                Some(_) => {}
+            },
+            _ => {}
         }
 
         let chunk = src.chunk();
-        match parse_frame_slice(chunk) {
+        match parse_frame_slice_bounded(chunk, self.max_frame_size) {
             Ok(Some((cmd_bytes, headers, body, consumed))) => {
                 // advance src by consumed
                 src.advance(consumed);
@@ -149,7 +175,20 @@ impl Decoder for StompCodec {
                 };
                 Ok(Some(StompItem::Frame(frame)))
             }
-            Ok(None) => Ok(None),
+            Ok(None) => {
+                // Incomplete frame. If we have already buffered the maximum and
+                // still cannot parse a whole frame, the frame is oversized (or
+                // never NUL-terminated) — bound it here rather than buffering
+                // without limit. The content-length path is bounded inside the
+                // parser; this covers the NUL-terminated body that never ends.
+                if src.len() > self.max_frame_size {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("frame exceeds maximum frame size {}", self.max_frame_size),
+                    ));
+                }
+                Ok(None)
+            }
             Err(e) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("parse error: {}", e),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -123,6 +123,21 @@ impl Decoder for StompCodec {
         let chunk = src.chunk();
         match parse_frame_slice_bounded(chunk, self.max_frame_size) {
             Ok(Some((cmd_bytes, headers, body, consumed))) => {
+                // Enforce the bound on a *complete* frame too, not only on the
+                // incomplete (`Ok(None)`) path. A whole oversized frame can
+                // arrive in one read — its body bounded inside the parser, but
+                // large headers or framing could still push the total over the
+                // limit — so reject on total wire size here as the authoritative
+                // guard.
+                if consumed > self.max_frame_size {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "frame size {} exceeds maximum frame size {}",
+                            consumed, self.max_frame_size
+                        ),
+                    ));
+                }
                 // advance src by consumed
                 src.advance(consumed);
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -10,6 +10,7 @@ use tokio_util::codec::Framed;
 
 use crate::codec::{StompCodec, StompItem};
 use crate::frame::Frame;
+use crate::parser::DEFAULT_MAX_FRAME_SIZE;
 
 /// Configuration for STOMP heartbeat intervals.
 ///
@@ -401,6 +402,13 @@ pub struct ConnectOptions {
     /// When set, the whole operation is bounded and, on expiry, the last
     /// error encountered is returned.
     pub connect_timeout: Option<Duration>,
+
+    /// Largest inbound frame to accept, in bytes. When `None`, the default is
+    /// [`crate::parser::DEFAULT_MAX_FRAME_SIZE`] (16 MiB). A frame larger than
+    /// this — whether via an oversized `content-length` or a body that never
+    /// terminates — is rejected as a `ConnError::Io`, so a malicious or buggy
+    /// broker cannot exhaust client memory or panic the decoder.
+    pub max_frame_size: Option<usize>,
 }
 
 impl std::fmt::Debug for ConnectOptions {
@@ -416,6 +424,7 @@ impl std::fmt::Debug for ConnectOptions {
             )
             .field("disconnect_timeout", &self.disconnect_timeout)
             .field("connect_timeout", &self.connect_timeout)
+            .field("max_frame_size", &self.max_frame_size)
             .finish()
     }
 }
@@ -499,6 +508,25 @@ impl ConnectOptions {
     /// ```
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Set the largest inbound frame to accept, in bytes (builder style).
+    ///
+    /// Defaults to [`crate::parser::DEFAULT_MAX_FRAME_SIZE`] (16 MiB). A frame
+    /// exceeding this — an oversized `content-length`, or a body that never
+    /// terminates — is rejected rather than buffered or allocated, so a
+    /// malicious or buggy broker cannot exhaust client memory. Raise it if you
+    /// legitimately exchange larger messages.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let options = ConnectOptions::default()
+    ///     .max_frame_size(64 * 1024 * 1024);
+    /// ```
+    pub fn max_frame_size(mut self, max_frame_size: usize) -> Self {
+        self.max_frame_size = Some(max_frame_size);
         self
     }
 
@@ -933,6 +961,7 @@ impl Connection {
         let custom_headers = options.headers;
         let heartbeat_notify_tx = options.heartbeat_tx;
         let connect_timeout = options.connect_timeout;
+        let max_frame_size = options.max_frame_size.unwrap_or(DEFAULT_MAX_FRAME_SIZE);
 
         // Perform initial connection and STOMP handshake before spawning
         // background task. Retries with exponential backoff on I/O and
@@ -964,7 +993,8 @@ impl Connection {
                         continue;
                     }
                 };
-                let mut framed = Framed::new(stream, StompCodec::new());
+                let mut framed =
+                    Framed::new(stream, StompCodec::with_max_frame_size(max_frame_size));
 
                 let connect = Self::build_connect_frame(
                     &accept_version,
@@ -1083,7 +1113,10 @@ impl Connection {
                     // Reconnection attempt
                     match TcpStream::connect(&addr).await {
                         Ok(stream) => {
-                            let mut framed = Framed::new(stream, StompCodec::new());
+                            let mut framed = Framed::new(
+                                stream,
+                                StompCodec::with_max_frame_size(max_frame_size),
+                            );
 
                             let connect = Self::build_connect_frame(
                                 &accept_version,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,12 +65,36 @@ fn get_content_length(headers: &[(Vec<u8>, Vec<u8>)]) -> Result<Option<usize>, S
     Ok(None)
 }
 
-/// Parse a single STOMP frame from a raw byte slice.
+/// Default upper bound on a single STOMP frame, in bytes (16 MiB).
+///
+/// A frame larger than this is rejected rather than buffered or allocated. The
+/// bound exists so a malicious or buggy broker cannot exhaust client memory —
+/// or panic the decoder with an overflowing `content-length` — by announcing an
+/// enormous frame. Override per connection with
+/// [`ConnectOptions::max_frame_size`](crate::ConnectOptions::max_frame_size).
+///
+/// [`parse_frame_slice`] uses this value; [`parse_frame_slice_bounded`] takes an
+/// explicit one.
+pub const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+/// Parse a single STOMP frame from a raw byte slice, bounding frame size at
+/// [`DEFAULT_MAX_FRAME_SIZE`].
 ///
 /// Returns Ok(Some((command, headers, body, consumed_bytes))) when a full frame
 /// was parsed and how many bytes were consumed. Returns Ok(None) when more
 /// bytes are required. Returns Err on protocol errors.
 pub fn parse_frame_slice(input: &[u8]) -> ParseResult {
+    parse_frame_slice_bounded(input, DEFAULT_MAX_FRAME_SIZE)
+}
+
+/// Parse a single STOMP frame, rejecting any `content-length` that exceeds
+/// `max_frame_size`.
+///
+/// Identical to [`parse_frame_slice`] except the caller chooses the size bound.
+/// Rejecting an oversized `content-length` up front is what keeps the length
+/// arithmetic (`pos + content_len + 1`) from overflowing and panicking the
+/// decoder — see the `content-length` branch below.
+pub fn parse_frame_slice_bounded(input: &[u8], max_frame_size: usize) -> ParseResult {
     let mut pos = 0usize;
     let len = input.len();
 
@@ -144,8 +168,24 @@ pub fn parse_frame_slice(input: &[u8]) -> ParseResult {
     // determine body strategy
     match get_content_length(&headers) {
         Ok(Some(content_len)) => {
-            // need content_len bytes, plus terminating NUL
-            if pos + content_len + 1 > len {
+            // Reject an oversized length before any arithmetic or allocation.
+            // Without this, a broker sending `content-length:<huge>` overflows
+            // `pos + content_len + 1` below — panicking the decoder (a remote
+            // DoS) — or makes the codec buffer unboundedly waiting for bytes
+            // that never come.
+            if content_len > max_frame_size {
+                return Err(format!(
+                    "content-length {} exceeds maximum frame size {}",
+                    content_len, max_frame_size
+                ));
+            }
+            // need content_len bytes, plus terminating NUL. Checked so that an
+            // enormous caller-supplied `max_frame_size` still cannot overflow.
+            let needed = match pos.checked_add(content_len).and_then(|n| n.checked_add(1)) {
+                Some(n) => n,
+                None => return Err("content-length too large".to_string()),
+            };
+            if needed > len {
                 Ok(None)
             } else {
                 let body = input[pos..pos + content_len].to_vec();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,6 +120,12 @@ pub fn parse_frame_slice_bounded(input: &[u8], max_frame_size: usize) -> ParseRe
         // No newline found: if there's a NUL in the remaining bytes, treat
         // this as a bare NUL-terminated body with empty command/headers.
         if let Some(nul_rel) = input[pos..].iter().position(|&b| b == 0) {
+            if nul_rel > max_frame_size {
+                return Err(format!(
+                    "frame body {} exceeds maximum frame size {}",
+                    nul_rel, max_frame_size
+                ));
+            }
             let body = input[pos..pos + nul_rel].to_vec();
             pos += nul_rel + 1;
             if pos < len && input[pos] == b'\n' {
@@ -207,6 +213,12 @@ pub fn parse_frame_slice_bounded(input: &[u8], max_frame_size: usize) -> ParseRe
             // NUL-terminated body: find NUL
             match input[pos..].iter().position(|&b| b == 0) {
                 Some(nul_rel) => {
+                    if nul_rel > max_frame_size {
+                        return Err(format!(
+                            "frame body {} exceeds maximum frame size {}",
+                            nul_rel, max_frame_size
+                        ));
+                    }
                     let body = input[pos..pos + nul_rel].to_vec();
                     pos += nul_rel + 1;
                     // optional trailing LF

--- a/tests/codec_heartbeat.rs
+++ b/tests/codec_heartbeat.rs
@@ -265,3 +265,71 @@ fn encode_frame_then_heartbeat() {
     assert_eq!(dst[len - 2], 0x00); // NUL terminator
     assert_eq!(dst[len - 1], 0x0A); // Heartbeat LF
 }
+
+// =============================================================================
+// CRLF heartbeat and frame-size guards
+// =============================================================================
+
+#[test]
+fn decode_crlf_as_heartbeat() {
+    // STOMP 1.2 allows the EOL heartbeat to be CRLF, not only a bare LF.
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&b"\r\n"[..]);
+    let item = codec
+        .decode(&mut buf)
+        .expect("decode failed")
+        .expect("no item");
+    assert_eq!(item, StompItem::Heartbeat);
+    assert!(
+        buf.is_empty(),
+        "buffer should be empty after CRLF heartbeat"
+    );
+}
+
+#[test]
+fn lone_cr_waits_for_more_bytes() {
+    // A bare CR could be the first half of a CRLF heartbeat; the codec must wait
+    // rather than consume or misparse it.
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&b"\r"[..]);
+    let item = codec.decode(&mut buf).expect("decode failed");
+    assert!(item.is_none(), "expected Ok(None) for a lone CR");
+    assert_eq!(buf.len(), 1, "buffer should be untouched");
+}
+
+#[test]
+fn oversized_content_length_frame_errors() {
+    // A content-length beyond the codec's bound is a hard error, not a panic and
+    // not unbounded buffering.
+    let mut codec = StompCodec::with_max_frame_size(1024);
+    let mut buf = BytesMut::from(&b"MESSAGE\ncontent-length:4000000000\n\nX\0"[..]);
+    let result = codec.decode(&mut buf);
+    assert!(
+        result.is_err(),
+        "expected an error for oversized content-length"
+    );
+}
+
+#[test]
+fn never_terminated_frame_is_bounded() {
+    // A frame with no content-length that never sends its NUL must not buffer
+    // past the bound. Feed more than the max and confirm the codec errors.
+    let mut codec = StompCodec::with_max_frame_size(64);
+    let mut buf = BytesMut::new();
+    buf.extend_from_slice(b"MESSAGE\ndestination:/q\n\n");
+    buf.extend_from_slice(&[b'x'; 128]); // body, no NUL, exceeds the bound
+    let result = codec.decode(&mut buf);
+    assert!(
+        result.is_err(),
+        "expected an error once the buffer exceeds the bound"
+    );
+}
+
+#[test]
+fn content_length_overflow_frame_errors_not_panics() {
+    // The end-to-end decode path must reject a usize::MAX-ish content-length.
+    let mut codec = StompCodec::new();
+    let mut buf = BytesMut::from(&b"MESSAGE\ncontent-length:18446744073709551615\n\nX\0"[..]);
+    let result = codec.decode(&mut buf);
+    assert!(result.is_err(), "expected an error, not a panic");
+}

--- a/tests/codec_heartbeat.rs
+++ b/tests/codec_heartbeat.rs
@@ -333,3 +333,20 @@ fn content_length_overflow_frame_errors_not_panics() {
     let result = codec.decode(&mut buf);
     assert!(result.is_err(), "expected an error, not a panic");
 }
+
+#[test]
+fn complete_oversized_frame_rejected_in_one_read() {
+    // A *complete* NUL-terminated frame (no content-length) larger than the
+    // bound, delivered whole in a single decode call, must be rejected — the
+    // guard cannot depend on the frame being incomplete.
+    let mut codec = StompCodec::with_max_frame_size(64);
+    let mut buf = BytesMut::new();
+    buf.extend_from_slice(b"MESSAGE\ndestination:/q\n\n");
+    buf.extend_from_slice(&[b'x'; 128]);
+    buf.extend_from_slice(&[0]); // NUL terminator present: the frame IS complete
+    let result = codec.decode(&mut buf);
+    assert!(
+        result.is_err(),
+        "a complete-but-oversized frame must be rejected"
+    );
+}

--- a/tests/parser_unit.rs
+++ b/tests/parser_unit.rs
@@ -451,7 +451,23 @@ fn content_length_over_the_bound_is_rejected() {
     assert!(
         result.is_err(),
         "expected an error, got {:?}",
-        result.is_ok()
+        result.map(|o| o.map(|t| t.3))
+    );
+}
+
+#[test]
+fn complete_oversized_nul_body_is_rejected() {
+    // A whole NUL-terminated frame with no content-length, larger than the
+    // bound, arriving all at once must be rejected — not accepted just because
+    // it is complete. Guards the gap where only content-length was bounded.
+    let mut raw = b"MESSAGE\ndestination:/q\n\n".to_vec();
+    raw.extend_from_slice(&[b'x'; 4096]);
+    raw.push(0);
+    let result = parse_frame_slice_bounded(&raw, 1024);
+    assert!(
+        result.is_err(),
+        "expected an error, got {:?}",
+        result.map(|o| o.map(|t| t.3))
     );
 }
 

--- a/tests/parser_unit.rs
+++ b/tests/parser_unit.rs
@@ -421,3 +421,48 @@ fn parse_only_nul() {
     assert!(result.1.is_empty());
     assert!(result.2.is_none());
 }
+
+// =============================================================================
+// Denial-of-service guards (malformed content-length)
+// =============================================================================
+
+use iridium_stomp::parser::parse_frame_slice_bounded;
+
+#[test]
+fn content_length_near_usize_max_errors_without_panicking() {
+    // A broker announcing a content-length near usize::MAX must not overflow
+    // the `pos + content_len + 1` arithmetic (which panicked the decoder before
+    // this guard). It is rejected as a protocol error instead.
+    let raw = b"MESSAGE\ncontent-length:18446744073709551615\n\nX\0";
+    let result = parse_frame_slice(raw);
+    assert!(
+        result.is_err(),
+        "expected an error, got {:?}",
+        result.map(|o| o.map(|t| t.3))
+    );
+}
+
+#[test]
+fn content_length_over_the_bound_is_rejected() {
+    // A large-but-non-overflowing content-length must be rejected rather than
+    // making the caller buffer unboundedly waiting for bytes that never come.
+    let raw = b"MESSAGE\ncontent-length:4000000000\n\nX\0";
+    let result = parse_frame_slice_bounded(raw, 1024);
+    assert!(
+        result.is_err(),
+        "expected an error, got {:?}",
+        result.is_ok()
+    );
+}
+
+#[test]
+fn content_length_within_the_bound_still_parses() {
+    // The guard must not reject a legitimate frame whose length is under the
+    // bound.
+    let raw = b"MESSAGE\ncontent-length:5\n\nhello\0";
+    let parsed = parse_frame_slice_bounded(raw, 1024)
+        .expect("parse error")
+        .expect("incomplete");
+    assert_eq!(parsed.0, b"MESSAGE");
+    assert_eq!(parsed.2.as_deref(), Some(&b"hello"[..]));
+}


### PR DESCRIPTION
…ing the client

The frame decoder trusted the broker's content-length without limit, so a malicious or buggy broker could crash or exhaust any connected client with a single frame. Two related weaknesses, found in a protocol-core review and verified against the live parser:

  1. A content-length near usize::MAX overflowed the length arithmetic `pos + content_len + 1` in parse_frame_slice. In a debug build that is an add-overflow panic; in release it wraps past the `> len` bounds check and then panics on the out-of-range slice `input[pos..pos + content_len]`. Either way the panic fires inside Decoder::decode, which runs on the connection's background I/O task, so one crafted frame takes the connection down. `content-length:18446744073709551615` is enough.

  2. A large-but-not-overflowing content-length (e.g. 4_000_000_000), or a frame that simply never sends its terminating NUL, made the codec return Ok(None) and buffer without limit while Framed grew the read buffer, waiting for bytes that never come — a memory-exhaustion DoS.

Both are now bounded by a maximum frame size, tunable per connection:

  - ConnectOptions::max_frame_size, defaulting to parser::DEFAULT_MAX_FRAME_SIZE (16 MiB). Raise it if you legitimately exchange larger messages; there is no way to disable the guard.
  - parse_frame_slice_bounded(input, max) rejects an oversized content-length as a protocol error before any arithmetic, and the remaining add is checked so that even an enormous caller-supplied max cannot overflow. parse_frame_slice(input) delegates at the default, so its signature — and the 49 existing parser tests — are unchanged.
  - StompCodec::with_max_frame_size(max) carries the bound; the decoder errors once a single incomplete frame exceeds it, covering the never-terminated case that content-length bounding alone does not.

Two lesser fixes from the same review, folded in here:

  - The decoder recognized only a bare LF as a heartbeat; STOMP 1.2 also permits CRLF as the EOL. A CRLF is now decoded as a heartbeat, and a lone trailing CR waits for the next byte rather than being misparsed.
  - The comment atop decode() described a nonexistent internal buffer and was a spliced half-sentence; rewritten to match what the code does.

All published 0.4.x releases are affected. Disclosed in the CHANGELOG's Security section rather than a public issue, since the fix ships in the next release.

Verified: new regression tests in tests/parser_unit.rs (usize::MAX length, over-bound, within-bound) and tests/codec_heartbeat.rs (CRLF heartbeat, lone CR, oversized content-length, never-terminated frame, end-to-end overflow) all pass, and the no-panic behaviour holds in both debug and release builds.