### PR TITLE
ci: run the whole test suite, doctests, and smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
           override: true
 
       - name: Run Rust smoke test
+        # stomp_smoke skips itself unless RUN_STOMP_SMOKE is set, so without
+        # this the job spun up RabbitMQ and then ran a test that no-op'd.
+        env:
+          RUN_STOMP_SMOKE: "1"
         run: |
           cargo test --test stomp_smoke -- --nocapture
 
@@ -167,15 +171,20 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Run unit tests
+      # `--lib` alone left every tests/*.rs integration file unrun, and the CLI
+      # lives behind the `cli` feature. `--lib --tests --features cli` covers the
+      # library unit tests and every integration file (including cli_oneshot) in
+      # one pass. The broker-dependent stomp_smoke self-skips unless
+      # RUN_STOMP_SMOKE is set, so it is a no-op here and runs in the smoke job.
+      - name: Run unit and integration tests
         run: |
-          cargo test --lib --verbose
+          cargo test --lib --tests --features cli --verbose
 
-      # The CLI lives behind the `cli` feature, so `--lib` never builds it and
-      # its tests would otherwise be written but never run.
-      - name: Run CLI tests
+      # Doc examples were never compiled by CI, so API drift silently rotted
+      # them. Compile and run them now (broker-touching examples are `no_run`).
+      - name: Run doc tests
         run: |
-          cargo test --test cli_oneshot --features cli --verbose
+          cargo test --doc --features cli --verbose
 
   build-examples:
     name: Build examples

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -17,10 +17,15 @@ iridium-stomp provides three ways to subscribe to a destination:
 
 The simplest form. No extra headers or options.
 
-```rust
+```rust,no_run
+# use iridium_stomp::Connection;
+# async fn wrapper(conn: Connection) -> Result<(), Box<dyn std::error::Error>> {
 use iridium_stomp::AckMode;
 
 let sub = conn.subscribe("/queue/orders", AckMode::Auto).await?;
+# let _ = sub;
+# Ok(())
+# }
 ```
 
 ### `subscribe_with_options(destination, ack, options)`
@@ -28,7 +33,9 @@ let sub = conn.subscribe("/queue/orders", AckMode::Auto).await?;
 Accepts a `SubscriptionOptions` struct for typed configuration. Use this
 when you need broker-specific headers, such as a durable subscription name.
 
-```rust
+```rust,no_run
+# use iridium_stomp::Connection;
+# async fn wrapper(conn: Connection) -> Result<(), Box<dyn std::error::Error>> {
 use iridium_stomp::{AckMode, SubscriptionOptions};
 
 let opts = SubscriptionOptions {
@@ -41,6 +48,9 @@ let opts = SubscriptionOptions {
 let sub = conn
     .subscribe_with_options("/topic/my-topic", AckMode::Client, opts)
     .await?;
+# let _ = sub;
+# Ok(())
+# }
 ```
 
 ### `subscribe_with_headers(destination, ack, extra_headers)`
@@ -49,7 +59,9 @@ Low-level convenience that forwards arbitrary header pairs on the
 SUBSCRIBE frame. Equivalent to `subscribe_with_options` with only the
 `headers` field set.
 
-```rust
+```rust,no_run
+# use iridium_stomp::Connection;
+# async fn wrapper(conn: Connection) -> Result<(), Box<dyn std::error::Error>> {
 use iridium_stomp::AckMode;
 
 let headers = vec![
@@ -58,6 +70,9 @@ let headers = vec![
 let sub = conn
     .subscribe_with_headers("/topic/events", AckMode::Client, headers)
     .await?;
+# let _ = sub;
+# Ok(())
+# }
 ```
 
 ---


### PR DESCRIPTION
Three gaps meant CI was passing while barely testing the crate.

- docs/subscriptions.md: the three subscribe examples were fenced plain ```rust, so rustdoc compiled each as a standalone program with an undefined `conn` and a top-level `.await?` — E0425 and E0728. They now use `no_run` with a hidden async wrapper that supplies `conn`, so they compile-check without a broker. This is what #98 is about: the examples had drifted (the SubscriptionOptions shape changed in #91) and nothing caught it because CI never compiled them.

- The unit-tests job ran only `cargo test --lib` plus one CLI file. Every other tests/*.rs integration file — 335 tests across 28 files, covering the parser, codec, heartbeats, receipts, reconnect, and fuzz/stress — was never run. It now runs `cargo test --lib --tests --features cli`, which covers the library unit tests and every integration file (including cli_oneshot) in one pass, plus `cargo test --doc` so the examples above stay honest.

- The smoke job built a RabbitMQ image, started it, waited for it to be ready, then ran stomp_smoke — which self-skips unless RUN_STOMP_SMOKE is set. It was not set, so the broker smoke test never actually ran; the job was theater. Set RUN_STOMP_SMOKE=1 so it exercises a real broker.

The broker-dependent stomp_smoke still self-skips in the no-broker unit-tests job, so `--tests` there is safe; it runs for real only in the smoke job.