### PR TITLE
fix(sub): unsubscribe on drop, prune dead subs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,13 @@ Every breaking change in this release is listed here, with its migration.
   - It was the only `with_`-prefixed builder on the type, and the only one in the public API; `accept_version`, `client_id`, `host`, `header`, and `disconnect_timeout` are all unprefixed, as is the convention for Rust builders. Renamed now because 0.5.0 is already a breaking release.
   - Migration: drop the `with_` prefix at the call site.
 - `send_frame_confirmed` is now a thin wrapper over `send_frame_with_receipt` + `ReceiptHandle::wait`, rather than duplicating the registration and timeout logic ([#82])
+- Dropping a `Subscription` now sends a best-effort UNSUBSCRIBE and prunes the subscription locally, instead of silently leaving it registered and streaming — and being replayed on reconnect ([#83]). `Subscription::unsubscribe` remains the explicit form that reports whether the frame was queued; `Subscription::into_receiver` hands the stream to the caller and suppresses the drop-time UNSUBSCRIBE. This aligns behaviour with what the subscriptions guide already described.
 
 ### Fixed
+
+- MESSAGE dispatch pruned dead subscriptions inconsistently across its two delivery paths ([#83])
+  - The subscription-id path always kept an entry even after its receiver was dropped, so a discarded subscription leaked and kept being replayed on reconnect. The destination path did the opposite and removed an entry on *any* send failure, including a merely full channel — so a slow-but-alive consumer could have its subscription silently dropped.
+  - Both paths now share one rule: a full channel (slow consumer) is kept and the message is dropped; only a closed channel (the receiving `Subscription` was dropped) is pruned. Emptied destination entries are removed too. This is also the backstop that reaps a dropped subscription whose best-effort `Drop` could not take the registry lock.
 
 - `Connection::close` did not terminate the background task; it reconnected indefinitely ([#96])
   - Every closed connection left a task re-establishing a broker session every 30s for the life of the process, so a long-running service accumulated them. From the broker's side this looked like sessions and reconnects with no client that owned them.
@@ -275,6 +280,7 @@ Every breaking change in this release is listed here, with its migration.
 [#81]: https://github.com/iridiumdesign/iridium-stomp/issues/81
 [#68]: https://github.com/iridiumdesign/iridium-stomp/issues/68
 [#82]: https://github.com/iridiumdesign/iridium-stomp/issues/82
+[#83]: https://github.com/iridiumdesign/iridium-stomp/issues/83
 [#91]: https://github.com/iridiumdesign/iridium-stomp/issues/91
 [#93]: https://github.com/iridiumdesign/iridium-stomp/issues/93
 [#96]: https://github.com/iridiumdesign/iridium-stomp/issues/96

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -133,9 +133,14 @@ reconnect.
 
 `unsubscribe` is the explicit form and reports whether the frame was queued.
 Dropping the handle does the same on a best-effort basis — it cannot report an
-error, and in the rare case the outbound channel is momentarily unavailable the
-frame may not be sent, though the subscription is still pruned locally so it is
-never resubscribed.
+error, and because it runs from `Drop` it uses non-blocking `try_lock`/`try_send`
+rather than awaiting. If the outbound channel is momentarily unavailable the
+frame may not be sent; if the subscription registry is momentarily locked, the
+local entry is not removed right then. In that case the entry is reaped when the
+next message for it is delivered (its receiver is closed), so pruning is
+eventual rather than guaranteed at the instant of drop — until it happens, a
+reconnect in that window could briefly resubscribe it. Use the explicit
+`unsubscribe` when you need the removal to be immediate and acknowledged.
 
 One exception: if you took the raw receiver with `into_receiver`, you now own
 the stream and dropping it sends nothing. Unsubscribe explicitly with

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -126,7 +126,17 @@ This means:
 
 ## Unsubscribe
 
-To stop receiving messages, drop the `Subscription` handle or call
-`unsubscribe`. The library sends an UNSUBSCRIBE frame and removes the
-subscription from its internal tracking so it will not be resubscribed
-on reconnect.
+To stop receiving messages, call `Subscription::unsubscribe` or simply drop
+the handle. Either way the library sends an UNSUBSCRIBE frame and removes the
+subscription from its internal tracking so it will not be resubscribed on
+reconnect.
+
+`unsubscribe` is the explicit form and reports whether the frame was queued.
+Dropping the handle does the same on a best-effort basis — it cannot report an
+error, and in the rare case the outbound channel is momentarily unavailable the
+frame may not be sent, though the subscription is still pruned locally so it is
+never resubscribed.
+
+One exception: if you took the raw receiver with `into_receiver`, you now own
+the stream and dropping it sends nothing. Unsubscribe explicitly with
+`Connection::unsubscribe` and the subscription id if you need to stop it.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -698,6 +698,23 @@ async fn lookup_destination_by_sub_id(
     None
 }
 
+/// Deliver a MESSAGE frame to one subscriber and report whether its entry
+/// should be kept.
+///
+/// The distinction the two delivery paths previously got wrong: a `Full`
+/// channel is a slow-but-live consumer — drop the message, keep the
+/// subscription — while a `Closed` channel means the receiving `Subscription`
+/// was dropped, so the entry is dead and must be pruned. Returning `false` only
+/// on `Closed` gives both paths one consistent rule and is the backstop that
+/// reaps a dropped subscription whose `Drop` could not take the registry lock.
+fn deliver_and_keep(entry: &SubscriptionEntry, frame: &Frame) -> bool {
+    match entry.sender.try_send(frame.clone()) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => true,
+        Err(mpsc::error::TrySendError::Closed(_)) => false,
+    }
+}
+
 /// High-level connection object that manages a single TCP/STOMP connection.
 ///
 /// The `Connection` spawns a background task that maintains the TCP transport,
@@ -1340,23 +1357,27 @@ impl Connection {
                                             }
                                         }
 
-                                        // Deliver to subscribers.
+                                        // Deliver to subscribers. Both paths use
+                                        // `deliver_and_keep` so a dropped
+                                        // subscriber (Closed channel) is pruned
+                                        // and a slow one (Full channel) is kept,
+                                        // then any emptied destination key is
+                                        // removed.
                                         if let Some(sub_id) = sub_opt {
                                             let mut map = subscriptions.lock().await;
                                             for vec in map.values_mut() {
                                                 vec.retain(|entry| {
-                                                    if entry.id == sub_id {
-                                                        let _ = entry.sender.try_send(f.clone());
-                                                        true
-                                                    } else {
-                                                        true
-                                                    }
+                                                    entry.id != sub_id || deliver_and_keep(entry, &f)
                                                 });
                                             }
+                                            map.retain(|_, vec| !vec.is_empty());
                                         } else if let Some(dest) = dest_opt {
                                             let mut map = subscriptions.lock().await;
                                             if let Some(vec) = map.get_mut(&dest) {
-                                                vec.retain(|entry| entry.sender.try_send(f.clone()).is_ok());
+                                                vec.retain(|entry| deliver_and_keep(entry, &f));
+                                                if vec.is_empty() {
+                                                    map.remove(&dest);
+                                                }
                                             }
                                         }
                                     } else if f.command == "RECEIPT" {
@@ -1845,6 +1866,28 @@ impl Connection {
             .map_err(|_| ConnError::Protocol("send channel closed".into()))?;
 
         Ok(())
+    }
+
+    /// Best-effort UNSUBSCRIBE for use from `Subscription`'s `Drop`.
+    ///
+    /// `Drop` cannot `.await`, so this cannot use the async paths: it
+    /// `try_lock`s the registry to remove the entry and `try_send`s the
+    /// UNSUBSCRIBE frame, and silently gives up on either if it would block. A
+    /// dropped subscription whose registry removal loses the lock race is still
+    /// reaped by [`deliver_and_keep`] on the next message, since its receiver is
+    /// now closed; the frame is the only part that can be genuinely missed (when
+    /// the outbound channel is full or gone), which is acceptable for a handle
+    /// that is being discarded rather than closed explicitly.
+    pub(crate) fn unsubscribe_best_effort(&self, subscription_id: &str) {
+        if let Ok(mut map) = self.subscriptions.try_lock() {
+            for vec in map.values_mut() {
+                vec.retain(|entry| entry.id != subscription_id);
+            }
+            map.retain(|_, vec| !vec.is_empty());
+        }
+
+        let f = Frame::new("UNSUBSCRIBE").header("id", subscription_id);
+        let _ = self.outbound_tx.try_send(StompItem::Frame(f));
     }
 
     /// Acknowledge a message previously received in `client` or
@@ -2369,6 +2412,38 @@ mod tests {
             result.as_ref().err()
         );
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn deliver_and_keep_keeps_full_prunes_closed() {
+        // A full channel is a slow-but-live consumer: drop the message, keep
+        // the subscription. Fill a capacity-1 channel so the next send is Full.
+        let (tx, _rx) = mpsc::channel::<Frame>(1);
+        tx.try_send(Frame::new("MESSAGE")).unwrap();
+        let full = SubscriptionEntry {
+            id: "1".into(),
+            sender: tx,
+            ack: "auto".into(),
+            headers: vec![],
+        };
+        assert!(
+            deliver_and_keep(&full, &Frame::new("MESSAGE")),
+            "a full (slow-consumer) channel must be kept, not pruned"
+        );
+
+        // A closed channel means the receiving Subscription was dropped: prune.
+        let (tx, rx) = mpsc::channel::<Frame>(1);
+        drop(rx);
+        let closed = SubscriptionEntry {
+            id: "2".into(),
+            sender: tx,
+            ack: "auto".into(),
+            headers: vec![],
+        };
+        assert!(
+            !deliver_and_keep(&closed, &Frame::new("MESSAGE")),
+            "a closed channel (dropped receiver) must be pruned"
+        );
     }
 
     #[tokio::test]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -47,6 +47,13 @@ pub struct Subscription {
     destination: String,
     receiver: mpsc::Receiver<Frame>,
     conn: Connection,
+    /// Set once the subscription has been unsubscribed explicitly, or once the
+    /// caller has taken ownership of the receiver via [`into_receiver`]. Guards
+    /// `Drop` against sending a second UNSUBSCRIBE, or any UNSUBSCRIBE when the
+    /// caller has chosen to keep driving the stream itself.
+    ///
+    /// [`into_receiver`]: Subscription::into_receiver
+    unsubscribed: bool,
 }
 
 impl Subscription {
@@ -61,6 +68,7 @@ impl Subscription {
             destination,
             receiver,
             conn,
+            unsubscribed: false,
         }
     }
 
@@ -76,8 +84,20 @@ impl Subscription {
 
     /// Consume the `Subscription` and return the underlying receiver so the
     /// caller can drive message handling directly.
-    pub fn into_receiver(self) -> mpsc::Receiver<Frame> {
-        self.receiver
+    ///
+    /// The subscription stays active: the caller now owns the stream, so `Drop`
+    /// does not send an UNSUBSCRIBE. Call [`Connection::unsubscribe`] with the
+    /// id if you later want to stop it.
+    ///
+    /// [`Connection::unsubscribe`]: crate::Connection::unsubscribe
+    pub fn into_receiver(mut self) -> mpsc::Receiver<Frame> {
+        // The caller keeps the stream, so suppress the drop-time UNSUBSCRIBE.
+        self.unsubscribed = true;
+        // `Subscription` implements `Drop`, so the receiver cannot be moved out
+        // directly (E0509). Swap in a throwaway and return the real one; the
+        // dummy is dropped harmlessly when `self` drops.
+        let (_dummy_tx, dummy_rx) = mpsc::channel(1);
+        std::mem::replace(&mut self.receiver, dummy_rx)
     }
 
     /// Acknowledge a message by its `message-id` header. Delegates to
@@ -94,9 +114,32 @@ impl Subscription {
     /// Consume the subscription and unsubscribe from the server.
     ///
     /// This is a convenience that calls `Connection::unsubscribe` with the
-    /// local subscription id and drops the receiver.
-    pub async fn unsubscribe(self) -> Result<(), ConnError> {
+    /// local subscription id and drops the receiver. It confirms nothing beyond
+    /// queuing the UNSUBSCRIBE; the returned error reports only that the frame
+    /// could not be queued. Dropping the handle instead does the same thing on a
+    /// best-effort basis (see the `Drop` impl).
+    pub async fn unsubscribe(mut self) -> Result<(), ConnError> {
+        // Mark first so the upcoming drop does not send a second UNSUBSCRIBE.
+        self.unsubscribed = true;
         self.conn.unsubscribe(&self.id).await
+    }
+}
+
+impl Drop for Subscription {
+    /// Best-effort UNSUBSCRIBE when the handle is dropped without an explicit
+    /// [`unsubscribe`](Subscription::unsubscribe).
+    ///
+    /// A dropped handle means the caller is done receiving, so the broker-side
+    /// subscription should stop rather than linger and keep delivering (and be
+    /// replayed on reconnect). `Drop` cannot `.await`, so this is best-effort
+    /// via [`Connection::unsubscribe_best_effort`]. It is skipped when the
+    /// subscription was already unsubscribed or when the receiver was handed off
+    /// through [`into_receiver`](Subscription::into_receiver).
+    fn drop(&mut self) {
+        if self.unsubscribed {
+            return;
+        }
+        self.conn.unsubscribe_best_effort(&self.id);
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -115,9 +115,11 @@ impl Subscription {
     ///
     /// This is a convenience that calls `Connection::unsubscribe` with the
     /// local subscription id and drops the receiver. It confirms nothing beyond
-    /// queuing the UNSUBSCRIBE; the returned error reports only that the frame
-    /// could not be queued. Dropping the handle instead does the same thing on a
-    /// best-effort basis (see the `Drop` impl).
+    /// queuing the UNSUBSCRIBE; the returned error means either the id was no
+    /// longer registered locally (for example the subscription had already been
+    /// abandoned after repeated broker errors) or the frame could not be queued.
+    /// Dropping the handle instead does the same thing on a best-effort basis
+    /// (see the `Drop` impl).
     pub async fn unsubscribe(mut self) -> Result<(), ConnError> {
         // Mark first so the upcoming drop does not send a second UNSUBSCRIBE.
         self.unsubscribed = true;

--- a/tests/subscription_drop.rs
+++ b/tests/subscription_drop.rs
@@ -1,0 +1,157 @@
+//! Coverage for #83: dropping a `Subscription` sends a best-effort UNSUBSCRIBE
+//! and stops the broker-side subscription, and does not double up with an
+//! explicit `unsubscribe`.
+
+use iridium_stomp::{AckMode, Connection};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+/// Raw frames the broker saw, in order.
+type Seen = Arc<Mutex<Vec<String>>>;
+
+/// A broker that answers CONNECT and records every frame it receives.
+fn start_broker() -> (String, Seen) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = seen.clone();
+
+    thread::spawn(move || {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        let mut buf = [0u8; 4096];
+
+        if stream.read(&mut buf).is_ok() {
+            let _ = stream.write_all(b"CONNECTED\nversion:1.2\nheart-beat:0,0\n\n\0");
+            let _ = stream.flush();
+        }
+
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let text = String::from_utf8_lossy(&buf[..n]).to_string();
+                    for raw in text.split('\0').filter(|f| !f.trim().is_empty()) {
+                        seen_clone
+                            .lock()
+                            .unwrap()
+                            .push(raw.trim_start().to_string());
+                    }
+                }
+            }
+        }
+
+        thread::sleep(Duration::from_millis(200));
+    });
+
+    (addr, seen)
+}
+
+/// The commands (first line of each recorded frame), in order.
+fn commands(seen: &Seen) -> Vec<String> {
+    seen.lock()
+        .unwrap()
+        .iter()
+        .map(|f| f.lines().next().unwrap_or("").to_string())
+        .collect()
+}
+
+/// The `id` header of the first frame whose command matches.
+fn id_of_command(seen: &Seen, command: &str) -> Option<String> {
+    seen.lock().unwrap().iter().find_map(|frame| {
+        let mut lines = frame.lines();
+        if lines.next()? != command {
+            return None;
+        }
+        frame.lines().find_map(|line| {
+            let (k, v) = line.split_once(':')?;
+            (k.eq_ignore_ascii_case("id")).then(|| v.to_string())
+        })
+    })
+}
+
+#[tokio::test]
+async fn dropping_a_subscription_sends_unsubscribe() {
+    let (addr, seen) = start_broker();
+    let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+        .await
+        .unwrap();
+
+    let sub = conn
+        .subscribe("/queue/orders", AckMode::Auto)
+        .await
+        .unwrap();
+    let sub_id = sub.id().to_string();
+    drop(sub);
+
+    // Give the drop's best-effort try_send and the broker thread a moment.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let cmds = commands(&seen);
+    assert!(
+        cmds.contains(&"UNSUBSCRIBE".to_string()),
+        "dropping a subscription must send UNSUBSCRIBE; broker saw {:?}",
+        cmds
+    );
+    assert_eq!(
+        id_of_command(&seen, "UNSUBSCRIBE").as_deref(),
+        Some(sub_id.as_str()),
+        "the UNSUBSCRIBE must carry the dropped subscription's id"
+    );
+}
+
+#[tokio::test]
+async fn explicit_unsubscribe_then_drop_sends_exactly_one() {
+    let (addr, seen) = start_broker();
+    let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+        .await
+        .unwrap();
+
+    let sub = conn
+        .subscribe("/queue/orders", AckMode::Auto)
+        .await
+        .unwrap();
+    sub.unsubscribe().await.unwrap(); // consumes `sub`, which then drops
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let unsub_count = commands(&seen)
+        .iter()
+        .filter(|c| *c == "UNSUBSCRIBE")
+        .count();
+    assert_eq!(
+        unsub_count, 1,
+        "explicit unsubscribe followed by drop must not send a second UNSUBSCRIBE"
+    );
+}
+
+#[tokio::test]
+async fn into_receiver_keeps_the_subscription_active() {
+    let (addr, seen) = start_broker();
+    let conn = Connection::connect(&addr, "guest", "guest", "0,0")
+        .await
+        .unwrap();
+
+    let sub = conn
+        .subscribe("/queue/orders", AckMode::Auto)
+        .await
+        .unwrap();
+    let rx = sub.into_receiver(); // caller takes the stream; must NOT unsubscribe
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    assert!(
+        !commands(&seen).contains(&"UNSUBSCRIBE".to_string()),
+        "into_receiver hands off the stream and must not unsubscribe"
+    );
+
+    // Dropping the raw receiver also must not send anything (it has no handle).
+    drop(rx);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(!commands(&seen).contains(&"UNSUBSCRIBE".to_string()));
+}

--- a/tests/subscription_drop.rs
+++ b/tests/subscription_drop.rs
@@ -31,16 +31,22 @@ fn start_broker() -> (String, Seen) {
             let _ = stream.flush();
         }
 
+        // TCP is a byte stream: a read may carry a partial frame or several at
+        // once. Accumulate bytes and record only complete, NUL-terminated
+        // frames so the assertions cannot see a split frame.
+        let mut acc: Vec<u8> = Vec::new();
         loop {
             match stream.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(n) => {
-                    let text = String::from_utf8_lossy(&buf[..n]).to_string();
-                    for raw in text.split('\0').filter(|f| !f.trim().is_empty()) {
-                        seen_clone
-                            .lock()
-                            .unwrap()
-                            .push(raw.trim_start().to_string());
+                    acc.extend_from_slice(&buf[..n]);
+                    while let Some(pos) = acc.iter().position(|&b| b == 0) {
+                        let frame: Vec<u8> = acc.drain(..=pos).collect();
+                        let text = String::from_utf8_lossy(&frame);
+                        let raw = text.trim_matches('\0').trim_start();
+                        if !raw.is_empty() {
+                            seen_clone.lock().unwrap().push(raw.to_string());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #83. Two connected problems: dropping a Subscription said nothing to the broker, and the two MESSAGE dispatch paths cleaned up dead subscriptions inconsistently.

Drop now unsubscribes. Subscription gains a Drop impl that sends a best-effort UNSUBSCRIBE and prunes the entry locally, so a discarded handle stops the broker-side subscription instead of leaving it registered, streaming, and replayed on every reconnect. Drop cannot .await, so this goes through a new Connection::unsubscribe_best_effort that try_locks the registry and try_sends the frame rather than blocking; the dispatch backstop below reaps the entry if the lock is contended.

  - An `unsubscribed` flag guards the double-send: unsubscribe(self) sets it so the ensuing drop stays quiet, and it reports queuing errors as before.
  - into_receiver hands the stream to the caller, so it sets the flag (no UNSUBSCRIBE on drop) and mem::replaces the receiver out — a field cannot be moved out of a type that implements Drop (E0509).

Dispatch cleanup unified. Delivery went two ways and each was wrong in a different direction: the subscription-id path always kept an entry even after its receiver was gone (dropped subscriptions leaked and were resubscribed), while the destination path removed an entry on any send failure including a merely full channel (a slow-but-alive consumer could be silently dropped). Both now share deliver_and_keep: a full channel is a slow consumer, so drop the message and keep the subscription; only a closed channel means the receiver was dropped, so prune it. Emptied destination keys are removed too.

The subscriptions guide already claimed drop unsubscribes; behaviour now matches the docs, which are also corrected for the best-effort nature of drop and the into_receiver exception.

Tested: dropping a subscription makes the broker see UNSUBSCRIBE with the right id; explicit unsubscribe then drop sends exactly one; into_receiver sends none; and deliver_and_keep keeps a full channel while pruning a closed one.