### PR TITLE
build: set MSRV 1.88, anchor include globs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "iridium-stomp"
 version = "0.4.2"
 edition = "2024"
+# Verified floor: edition 2024 needs 1.85, and the let-chain in connection.rs
+# needs 1.88. Library and the `cli` feature both build on 1.88.0.
+rust-version = "1.88"
 license = "MIT"
 authors = ["Brad Siegfreid <bsiegfreid@me.com>"]
 description = "Async STOMP 1.2 client for Rust"
@@ -11,8 +14,10 @@ homepage = "https://github.com/iridiumdesign/iridium-stomp"
 documentation = "https://docs.rs/iridium-stomp"
 keywords = ["stomp", "async", "messaging", "tokio", "rabbitmq"]
 categories = ["network-programming", "asynchronous"]
-# Ensure docs files are packaged and instruct docs.rs to build with all features
-include = ["src/**", "examples/**", "docs/**", "Cargo.toml", "README.md", "LICENSE"]
+# Ensure docs files are packaged and instruct docs.rs to build with all features.
+# Leading slashes anchor to the package root: an unanchored `README.md` also
+# matched `.github/scripts/README.md` and shipped it in the crate tarball.
+include = ["/src/**", "/examples/**", "/docs/**", "/Cargo.toml", "/README.md", "/LICENSE"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Two packaging-hygiene fixes ahead of the 0.5.0 release.

rust-version = "1.88". Edition 2024 needs 1.85, but the let-chain in connection.rs (`if let Some(ref id) = sub_id && ...`) needs 1.88, which is the real floor. Verified by building both the library and the cli feature on a 1.88.0 toolchain. With the field set, a user on an older toolchain gets cargo's clean "requires rustc 1.88" message instead of a confusing mid-compile error.

Anchored include globs. The globs were an allowlist for the published tarball, but `README.md` and `LICENSE` had no leading slash, so they matched at any depth — `.github/scripts/README.md` was being shipped inside the crate. Leading slashes anchor each pattern to the package root; `cargo package --list` now shows only the intended root files.