### PR TITLE
fix(cli): connect timeout, UTF-8-safe rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,14 +171,15 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      # `--lib` alone left every tests/*.rs integration file unrun, and the CLI
-      # lives behind the `cli` feature. `--lib --tests --features cli` covers the
-      # library unit tests and every integration file (including cli_oneshot) in
-      # one pass. The broker-dependent stomp_smoke self-skips unless
-      # RUN_STOMP_SMOKE is set, so it is a no-op here and runs in the smoke job.
+      # `--all-targets` covers the library unit tests, the binary's own unit
+      # tests (src/bin/cli/*), and every integration file (including
+      # cli_oneshot) in one pass — `--lib --tests` skipped the binary tests. The
+      # `cli` feature builds the binary at all. The broker-dependent stomp_smoke
+      # self-skips unless RUN_STOMP_SMOKE is set, so it is a no-op here and runs
+      # in the smoke job.
       - name: Run unit and integration tests
         run: |
-          cargo test --lib --tests --features cli --verbose
+          cargo test --all-targets --features cli --verbose
 
       # Doc examples were never compiled by CI, so API drift silently rotted
       # them. Compile and run them now (broker-touching examples are `no_run`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ Every breaking change in this release is listed here, with its migration.
 
 ### Fixed
 
+- The interactive CLI and TUI hung forever against an unreachable broker ([#101]). They now apply the `--timeout` bound to the connection (via `ConnectOptions::connect_timeout`, added in [#68]), so `stomp -a <dead>` and `stomp --tui -a <dead>` exit with `NETWORK_ERROR` instead of retrying indefinitely. `--timeout` (default 5s) is no longer restricted to `--send`; raise it if you expect to wait for a broker that is still coming up.
+- The TUI and the session summary/report panicked on multibyte message bodies, headers, or broker errors. Display truncation and line-wrapping sliced strings by byte offset, so a cut landing inside a UTF-8 character (accents, emoji, CJK — ordinary payloads for a messaging client) aborted the render or the report; in the TUI that also left the terminal in raw mode. Truncation and wrapping now operate on character boundaries, and the TUI installs a panic hook that restores the terminal on any unexpected panic.
+
 - MESSAGE dispatch pruned dead subscriptions inconsistently across its two delivery paths ([#83])
   - The subscription-id path always kept an entry even after its receiver was dropped, so a discarded subscription leaked and kept being replayed on reconnect. The destination path did the opposite and removed an entry on *any* send failure, including a merely full channel — so a slow-but-alive consumer could have its subscription silently dropped.
   - Both paths now share one rule: a full channel (slow consumer) is kept and the message is dropped; only a closed channel (the receiving `Subscription` was dropped) is pruned. Emptied destination entries are removed too. This is also the backstop that reaps a dropped subscription whose best-effort `Drop` could not take the registry lock.
@@ -284,3 +287,4 @@ Every breaking change in this release is listed here, with its migration.
 [#91]: https://github.com/iridiumdesign/iridium-stomp/issues/91
 [#93]: https://github.com/iridiumdesign/iridium-stomp/issues/93
 [#96]: https://github.com/iridiumdesign/iridium-stomp/issues/96
+[#101]: https://github.com/iridiumdesign/iridium-stomp/issues/101

--- a/src/bin/cli/args.rs
+++ b/src/bin/cli/args.rs
@@ -46,8 +46,10 @@ pub struct Cli {
     )]
     pub send: Option<Vec<String>>,
 
-    /// Seconds to wait for the broker during a --send, covering both the
-    /// connection and the receipt
-    #[arg(long, default_value_t = 5, requires = "send", value_name = "SECONDS")]
+    /// Seconds to wait for the broker connection before giving up. With --send
+    /// it also bounds the receipt wait. Without this bound an unreachable broker
+    /// would hang the client indefinitely; raise it if you expect to wait for a
+    /// broker that is still coming up.
+    #[arg(long, default_value_t = 5, value_name = "SECONDS")]
     pub timeout: u64,
 }

--- a/src/bin/cli/plain.rs
+++ b/src/bin/cli/plain.rs
@@ -21,8 +21,11 @@ pub async fn run(cli: &Cli) -> Result<(), (String, u8)> {
     // Create heartbeat notification channel
     let (hb_tx, mut hb_rx) = mpsc::channel::<()>(16);
 
-    // Build connection options
-    let options = ConnectOptions::default().heartbeat_notify(hb_tx);
+    // Build connection options. Bound the connect so an unreachable broker
+    // fails fast instead of retrying forever (#101).
+    let options = ConnectOptions::default()
+        .heartbeat_notify(hb_tx)
+        .connect_timeout(std::time::Duration::from_secs(cli.timeout));
 
     let conn = Connection::connect_with_options(
         &cli.address,

--- a/src/bin/cli/state.rs
+++ b/src/bin/cli/state.rs
@@ -382,15 +382,35 @@ impl AppState {
     }
 }
 
-/// Truncate a string to max_len characters, adding "..." if truncated
-fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+/// Truncate a string to at most `max_len` characters, adding "..." if it had to
+/// cut.
+///
+/// Works on `char` boundaries, never byte offsets, so it cannot panic on
+/// multibyte input (accents, emoji, CJK). A message body or broker error
+/// carrying such text used to slice mid-character and crash the render/report.
+pub(crate) fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
         s.to_string()
     } else if max_len <= 3 {
         ".".repeat(max_len)
     } else {
-        format!("{}...", &s[..max_len - 3])
+        let kept: String = s.chars().take(max_len - 3).collect();
+        format!("{}...", kept)
     }
+}
+
+/// Split `s` into pieces of at most `width` characters each, on `char`
+/// boundaries. Used to wrap long text across terminal lines without ever
+/// slicing a multibyte character.
+pub(crate) fn char_wrap(s: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+    let chars: Vec<char> = s.chars().collect();
+    chars
+        .chunks(width)
+        .map(|chunk| chunk.iter().collect())
+        .collect()
 }
 
 /// Thread-safe shared state
@@ -399,4 +419,36 @@ pub type SharedState = Arc<Mutex<AppState>>;
 /// Create a new shared state
 pub fn new_shared_state(host: String, user: String, heartbeat_interval_ms: u32) -> SharedState {
     Arc::new(Mutex::new(AppState::new(host, user, heartbeat_interval_ms)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{char_wrap, truncate_str};
+
+    #[test]
+    fn truncate_str_never_panics_on_multibyte() {
+        // Byte-index slicing used to panic when the cut fell inside a multibyte
+        // char. These must truncate cleanly instead.
+        assert_eq!(truncate_str("aaaaéaaaaaaaaaa", 8), "aaaaé...");
+        let out = truncate_str("hello 🌦 world weather report", 11);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), 11);
+    }
+
+    #[test]
+    fn truncate_str_passes_short_and_handles_tiny_max() {
+        assert_eq!(truncate_str("short", 10), "short");
+        assert_eq!(truncate_str("", 5), "");
+        assert_eq!(truncate_str("hello", 3), "...");
+        assert_eq!(truncate_str("hello", 2), "..");
+    }
+
+    #[test]
+    fn char_wrap_splits_on_char_boundaries_and_reassembles() {
+        let s = "aaébbédd"; // 8 chars, multibyte in the middle
+        let chunks = char_wrap(s, 3);
+        assert_eq!(chunks, vec!["aaé", "bbé", "dd"]);
+        assert_eq!(chunks.concat(), s);
+        assert!(char_wrap("abc", 0).is_empty());
+    }
 }

--- a/src/bin/cli/tui.rs
+++ b/src/bin/cli/tui.rs
@@ -1,4 +1,5 @@
 use crossterm::{
+    cursor::Show,
     event::{self, Event, KeyCode, KeyModifiers},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -19,7 +20,7 @@ use tokio::sync::mpsc;
 
 use super::args::Cli;
 use super::commands::{CommandResult, execute_command};
-use super::state::{SharedState, new_shared_state};
+use super::state::{SharedState, char_wrap, new_shared_state, truncate_str};
 
 /// TUI Application
 pub struct App {
@@ -50,8 +51,11 @@ pub async fn run(cli: &Cli) -> Result<(), (String, u8)> {
     // Create heartbeat notification channel
     let (hb_tx, mut hb_rx) = mpsc::channel::<()>(16);
 
-    // Build connection options
-    let options = ConnectOptions::default().heartbeat_notify(hb_tx);
+    // Build connection options. Bound the connect so an unreachable broker
+    // fails fast instead of retrying forever (#101).
+    let options = ConnectOptions::default()
+        .heartbeat_notify(hb_tx)
+        .connect_timeout(std::time::Duration::from_secs(cli.timeout));
 
     let conn = Connection::connect_with_options(
         &cli.address,
@@ -124,6 +128,17 @@ pub async fn run(cli: &Cli) -> Result<(), (String, u8)> {
             }
         }
     });
+
+    // Restore the terminal even if a panic unwinds past the normal teardown
+    // below, so a crash never strands the user in raw mode / the alternate
+    // screen. The hook chains to the previous one so the panic message still
+    // prints — now onto a restored screen.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen, Show);
+        original_hook(info);
+    }));
 
     // Setup terminal
     enable_raw_mode().map_err(|e| (format!("Failed to enable raw mode: {}", e), 1))?;
@@ -531,18 +546,17 @@ fn render_messages(f: &mut ratatui::Frame, area: Rect, state: &super::state::App
             _ => (Style::default().fg(Color::Cyan), Style::default(), 60),
         };
 
-        let dest_display = if msg.destination.len() > 20 {
-            format!("...{}", &msg.destination[msg.destination.len() - 17..])
+        // Char-safe tail: keep the last 17 characters with a leading ellipsis.
+        let dest_char_count = msg.destination.chars().count();
+        let dest_display = if dest_char_count > 20 {
+            let tail: String = msg.destination.chars().skip(dest_char_count - 17).collect();
+            format!("...{}", tail)
         } else {
             msg.destination.clone()
         };
 
-        // Truncate body for display
-        let body_display = if msg.body.len() > max_body_len {
-            format!("{}...", &msg.body[..max_body_len - 3])
-        } else {
-            msg.body.clone()
-        };
+        // Truncate body for display (char-safe; never slices a multibyte char).
+        let body_display = truncate_str(&msg.body, max_body_len);
 
         lines.push(Line::from(vec![
             Span::styled(time, Style::default().fg(Color::DarkGray)),
@@ -559,11 +573,7 @@ fn render_messages(f: &mut ratatui::Frame, area: Rect, state: &super::state::App
                     break;
                 }
                 let header_line = format!("    {}: {}", k, v);
-                let truncated = if header_line.len() > 70 {
-                    format!("{}...", &header_line[..67])
-                } else {
-                    header_line
-                };
+                let truncated = truncate_str(&header_line, 70);
                 lines.push(Line::from(vec![Span::styled(
                     truncated,
                     Style::default().fg(Color::DarkGray),
@@ -613,66 +623,50 @@ fn render_errors(f: &mut ratatui::Frame, area: Rect, state: &super::state::AppSt
 
         let time = err.timestamp.format("%H:%M:%S").to_string();
 
-        // First line: timestamp + start of error
+        // First line: timestamp + start of error. All wrapping is char-safe
+        // (char_wrap), so a multibyte error body never slices mid-character.
         let prefix_len = time.len() + 1; // "HH:MM:SS "
         let first_line_body_len = line_width.saturating_sub(prefix_len);
+        let indent = "         "; // 9 spaces to align with text after timestamp
+        let cont_width = line_width.saturating_sub(indent.len());
 
-        if err.body.len() <= first_line_body_len {
-            // Fits on one line
-            lines.push(Line::from(vec![
-                Span::styled(time, Style::default().fg(Color::DarkGray)),
-                Span::raw(" "),
-                Span::styled(&err.body, Style::default().fg(Color::Red)),
-            ]));
-        } else {
-            // Wrap across multiple lines
-            lines.push(Line::from(vec![
-                Span::styled(time, Style::default().fg(Color::DarkGray)),
-                Span::raw(" "),
-                Span::styled(
-                    &err.body[..first_line_body_len],
-                    Style::default().fg(Color::Red),
-                ),
-            ]));
+        let body_lines = char_wrap(&err.body, first_line_body_len);
+        let mut body_iter = body_lines.into_iter();
 
-            // Continuation lines (indented)
-            let indent = "         "; // 9 spaces to align with text after timestamp
-            let cont_width = line_width.saturating_sub(indent.len());
-            let mut pos = first_line_body_len;
+        // First body chunk shares the timestamp line.
+        let first_chunk = body_iter.next().unwrap_or_default();
+        lines.push(Line::from(vec![
+            Span::styled(time, Style::default().fg(Color::DarkGray)),
+            Span::raw(" "),
+            Span::styled(first_chunk, Style::default().fg(Color::Red)),
+        ]));
 
-            while pos < err.body.len() && lines.len() < visible_height {
-                let end = (pos + cont_width).min(err.body.len());
-                lines.push(Line::from(vec![
-                    Span::raw(indent),
-                    Span::styled(&err.body[pos..end], Style::default().fg(Color::Red)),
-                ]));
-                pos = end;
+        // Remaining characters wrap onto indented continuation lines. Re-wrap
+        // the tail at the (narrower) continuation width.
+        let consumed: usize = err.body.chars().take(first_line_body_len).count();
+        let tail: String = err.body.chars().skip(consumed).collect();
+        for chunk in char_wrap(&tail, cont_width) {
+            if lines.len() >= visible_height {
+                break;
             }
+            lines.push(Line::from(vec![
+                Span::raw(indent),
+                Span::styled(chunk, Style::default().fg(Color::Red)),
+            ]));
         }
 
         // Show headers if toggled
         if state.show_headers && !err.headers.is_empty() {
             for (k, v) in &err.headers {
-                if lines.len() >= visible_height {
-                    break;
-                }
                 let header_line = format!("  {}: {}", k, v);
-                // Wrap header lines too
-                if header_line.len() <= line_width {
+                for chunk in char_wrap(&header_line, line_width) {
+                    if lines.len() >= visible_height {
+                        break;
+                    }
                     lines.push(Line::from(vec![Span::styled(
-                        header_line,
+                        chunk,
                         Style::default().fg(Color::DarkGray),
                     )]));
-                } else {
-                    let mut pos = 0;
-                    while pos < header_line.len() && lines.len() < visible_height {
-                        let end = (pos + line_width).min(header_line.len());
-                        lines.push(Line::from(vec![Span::styled(
-                            header_line[pos..end].to_string(),
-                            Style::default().fg(Color::DarkGray),
-                        )]));
-                        pos = end;
-                    }
                 }
             }
         }

--- a/tests/cli_oneshot.rs
+++ b/tests/cli_oneshot.rs
@@ -226,6 +226,32 @@ fn send_to_an_unreachable_broker_times_out_rather_than_retrying_forever() {
 }
 
 #[test]
+fn interactive_at_an_unreachable_broker_times_out_rather_than_hanging() {
+    // #101: the interactive client now shares the connect bound, so a dead
+    // broker exits NETWORK_ERROR instead of hanging forever. stdin is null so
+    // the test never blocks even if the connect somehow succeeded.
+    let started = Instant::now();
+    let out = Command::new(env!("CARGO_BIN_EXE_stomp"))
+        .args(["-a", "127.0.0.1:59998", "--timeout", "1"])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to run the stomp binary");
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        out.status.code(),
+        Some(NETWORK_ERROR),
+        "stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "interactive connect to a dead broker must fail fast (took {:?})",
+        elapsed
+    );
+}
+
+#[test]
 fn send_rejects_a_destination_that_is_not_a_path() {
     let (addr, _seen) = start_broker(OnSend::Receipt);
 

--- a/tests/cli_oneshot.rs
+++ b/tests/cli_oneshot.rs
@@ -118,6 +118,36 @@ fn stomp(args: &[&str]) -> std::process::Output {
         .expect("failed to run the stomp binary")
 }
 
+/// Run the binary with a hard wall-clock bound, killing it if it overruns.
+///
+/// The hang-avoidance tests below guard against the binary blocking forever;
+/// `Command::output()` would itself block forever on exactly that regression and
+/// stall the whole suite. This spawns, polls, and kills a runaway child so a
+/// regression fails fast with a clear message instead. stdin is null so an
+/// interactive binary never blocks on it.
+fn run_bounded(args: &[&str], kill_after: Duration) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_stomp"))
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn the stomp binary");
+
+    let start = Instant::now();
+    loop {
+        if child.try_wait().expect("try_wait failed").is_some() {
+            return child.wait_with_output().expect("failed to collect output");
+        }
+        if start.elapsed() > kill_after {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("stomp did not exit within {:?}; it is hanging", kill_after);
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Exit codes from `src/bin/cli/mod.rs::exit_codes`.
 const SUCCESS: i32 = 0;
 const NETWORK_ERROR: i32 = 1;
@@ -171,17 +201,18 @@ fn send_rejected_by_the_broker_exits_frame_rejected() {
 fn send_to_a_silent_broker_times_out_rather_than_hanging() {
     let (addr, _seen) = start_broker(OnSend::Silence);
 
-    let started = Instant::now();
-    let out = stomp(&[
-        "-a",
-        &addr,
-        "--send",
-        "/queue/x",
-        "payload",
-        "--timeout",
-        "1",
-    ]);
-    let elapsed = started.elapsed();
+    let out = run_bounded(
+        &[
+            "-a",
+            &addr,
+            "--send",
+            "/queue/x",
+            "payload",
+            "--timeout",
+            "1",
+        ],
+        Duration::from_secs(10),
+    );
 
     assert_eq!(
         out.status.code(),
@@ -189,65 +220,49 @@ fn send_to_a_silent_broker_times_out_rather_than_hanging() {
         "stderr: {}",
         stderr(&out)
     );
-    assert!(
-        elapsed < Duration::from_secs(10),
-        "--timeout must bound the wait (took {:?})",
-        elapsed
-    );
 }
 
 #[test]
 fn send_to_an_unreachable_broker_times_out_rather_than_retrying_forever() {
     // Connection::connect retries indefinitely (#68), so without an explicit
-    // bound in the one-shot path this would never return.
-    let started = Instant::now();
-    let out = stomp(&[
-        "-a",
-        "127.0.0.1:59999",
-        "--send",
-        "/queue/x",
-        "payload",
-        "--timeout",
-        "2",
-    ]);
-    let elapsed = started.elapsed();
+    // bound in the one-shot path this would never return. run_bounded kills a
+    // hung binary so a regression fails fast instead of stalling the suite.
+    let out = run_bounded(
+        &[
+            "-a",
+            "127.0.0.1:59999",
+            "--send",
+            "/queue/x",
+            "payload",
+            "--timeout",
+            "2",
+        ],
+        Duration::from_secs(15),
+    );
 
     assert_eq!(
         out.status.code(),
         Some(NETWORK_ERROR),
         "stderr: {}",
         stderr(&out)
-    );
-    assert!(
-        elapsed < Duration::from_secs(15),
-        "a dead broker must fail fast, not retry forever (took {:?})",
-        elapsed
     );
 }
 
 #[test]
 fn interactive_at_an_unreachable_broker_times_out_rather_than_hanging() {
     // #101: the interactive client now shares the connect bound, so a dead
-    // broker exits NETWORK_ERROR instead of hanging forever. stdin is null so
-    // the test never blocks even if the connect somehow succeeded.
-    let started = Instant::now();
-    let out = Command::new(env!("CARGO_BIN_EXE_stomp"))
-        .args(["-a", "127.0.0.1:59998", "--timeout", "1"])
-        .stdin(std::process::Stdio::null())
-        .output()
-        .expect("failed to run the stomp binary");
-    let elapsed = started.elapsed();
+    // broker exits NETWORK_ERROR instead of hanging forever. run_bounded kills
+    // it if it regresses to hanging, so the suite can't stall.
+    let out = run_bounded(
+        &["-a", "127.0.0.1:59998", "--timeout", "1"],
+        Duration::from_secs(10),
+    );
 
     assert_eq!(
         out.status.code(),
         Some(NETWORK_ERROR),
         "stderr: {}",
         stderr(&out)
-    );
-    assert!(
-        elapsed < Duration::from_secs(10),
-        "interactive connect to a dead broker must fail fast (took {:?})",
-        elapsed
     );
 }
 


### PR DESCRIPTION
Two CLI fixes plus the CI change that makes their tests run.

#101 — the interactive client and TUI hung forever at an unreachable broker. Connection::connect retries indefinitely (#68), and neither interactive path bounded it. They now pass --timeout through to ConnectOptions::connect_timeout, so `stomp -a <dead>` and `stomp --tui -a <dead>` exit NETWORK_ERROR instead of retrying forever. --timeout (default 5s) is no longer restricted to --send; raise it to wait for a broker that is still coming up. Verified against a dead broker: exits in ~1s, not a hang.

UTF-8 truncation panics — the TUI and the summary/report sliced strings by byte offset for display truncation and line-wrapping. A cut landing inside a multibyte character (accents, emoji, CJK — ordinary messaging payloads) panicked the render or the report, and in the TUI left the terminal in raw mode. All truncation and wrapping now works on char boundaries via truncate_str/char_wrap, and the TUI installs a panic hook that restores the terminal on any panic. truncate_str's doc no longer claims "characters" while counting bytes.

CI — `--lib --tests` never ran the binary's own unit tests (src/bin/cli/*), so even the existing plain.rs test never ran. Switched to `cargo test --all-targets` so the binary unit tests run alongside the rest.

Tested: new bin unit tests prove truncate_str/char_wrap are char-safe on multibyte input, and a new integration test drives the real binary at a dead broker and asserts a fast NETWORK_ERROR exit rather than a hang.